### PR TITLE
fix: adjust import path for page.css on transaccion completa mall

### DIFF
--- a/src/app/transaccion-completa-mall/refund/page.tsx
+++ b/src/app/transaccion-completa-mall/refund/page.tsx
@@ -5,7 +5,7 @@ import { getRefundSteps } from "../content/steps/refund";
 import { NextPageProps } from "@/types/general";
 import { TBKRefundMallTransactionResponse } from "@/types/transactions";
 import { refundFullTransactionMallTransaction } from "@/app/lib/transaccion-completa-mall/data";
-import "./Page.css";
+import "./page.css";
 
 const navigationItems: NavigationItem[] = [
   {


### PR DESCRIPTION
This PR fixes a wrong typo in the import path on the refund page for transaccion completa mall