### PR TITLE
fix: remove unused props for full transaction mall deferred

### DIFF
--- a/src/app/transaccion-completa-mall-diferido/commit/page.tsx
+++ b/src/app/transaccion-completa-mall-diferido/commit/page.tsx
@@ -72,8 +72,7 @@ export default async function CommitFullTransactionMallPage({
   const trxData = await commitFullTransactionMallTransaction(
     token_ws as string,
     JSON.parse(data.value) as TransactionDetail[],
-    installmentsData,
-    true
+    installmentsData
   );
 
   return (

--- a/src/app/transaccion-completa-mall-diferido/installments/page.tsx
+++ b/src/app/transaccion-completa-mall-diferido/installments/page.tsx
@@ -50,8 +50,7 @@ export default async function InstallmentsFullTransactionMallPage({
   const trxData = await setupInstallmentsFullTransactionMall(
     token_ws,
     JSON.parse(data.value) as TransactionDetail[],
-    Number(installments_number),
-    true
+    Number(installments_number)
   );
 
   return (

--- a/src/app/transaccion-completa-mall-diferido/refund/page.tsx
+++ b/src/app/transaccion-completa-mall-diferido/refund/page.tsx
@@ -36,15 +36,12 @@ export default async function RefundFullTransactionMallPage({
   const { token_ws, amount, child_buy_order, child_commerce_code } =
     searchParams;
 
-  const trxData = await refundFullTransactionMallTransaction(
-    {
-      token: token_ws,
-      buyOrder: child_buy_order,
-      commerceCode: child_commerce_code,
-      amount: Number(amount),
-    },
-    true
-  );
+  const trxData = await refundFullTransactionMallTransaction({
+    token: token_ws,
+    buyOrder: child_buy_order,
+    commerceCode: child_commerce_code,
+    amount: Number(amount),
+  });
 
   return (
     <Layout

--- a/src/app/transaccion-completa-mall-diferido/status/page.tsx
+++ b/src/app/transaccion-completa-mall-diferido/status/page.tsx
@@ -37,10 +37,7 @@ export default async function StatusTransactionView({
 }: NextPageProps) {
   const { token_ws } = searchParams;
 
-  const trxStatus = await getStatusFullTransactionMallTransaction(
-    token_ws,
-    true
-  );
+  const trxStatus = await getStatusFullTransactionMallTransaction(token_ws);
 
   return (
     <>


### PR DESCRIPTION
This PR removes some props that are no longer used in a function related to full transaction mall deferred.