### PR TITLE
feat: add error handling in aborted views

### DIFF
--- a/src/app/webpay-mall-diferido/commit/error/aborted.tsx
+++ b/src/app/webpay-mall-diferido/commit/error/aborted.tsx
@@ -6,6 +6,7 @@ import { getStatusTRXSteps } from "../../content/steps/status";
 import { getStatusTransaction } from "@/app/lib/webpay-mall/data";
 import { getErrorAbortedSteps } from "../../content/steps/error-aborted";
 import { TBKAbortedResponse } from "@/types/transactions";
+import { CustomError } from "@/components/customError/CustomError";
 
 const actualBread: Route[] = [
   {
@@ -30,6 +31,13 @@ export const AbortedView = async (props: AbortedViewProps) => {
   const statusResponse = await getStatusTransaction(
     props.abortedResponse.TBK_TOKEN
   );
+
+  if ("errorMessage" in statusResponse) {
+    return (
+      <CustomError  errorMessage={statusResponse.errorMessage} actualBread={actualBread}/>
+    );
+  }
+  
   return (
     <>
       <Head>

--- a/src/app/webpay-mall/commit/error/aborted.tsx
+++ b/src/app/webpay-mall/commit/error/aborted.tsx
@@ -6,6 +6,7 @@ import { getStatusTRXSteps } from "../../content/steps/status";
 import { getStatusTransaction } from "@/app/lib/webpay-mall/data";
 import { getErrorAbortedSteps } from "../../content/steps/error-aborted";
 import { TBKAbortedResponse } from "@/types/transactions";
+import { CustomError } from "@/components/customError/CustomError";
 
 const actualBread: Route[] = [
   {
@@ -30,6 +31,13 @@ export const AbortedView = async (props: AbortedViewProps) => {
   const statusResponse = await getStatusTransaction(
     props.abortedResponse.TBK_TOKEN
   );
+
+  if ("errorMessage" in statusResponse) {
+    return (
+      <CustomError  errorMessage={statusResponse.errorMessage} actualBread={actualBread}/>
+    );
+  }
+  
   return (
     <>
       <Head>

--- a/src/app/webpay-plus-deferred/commit/error/aborted.tsx
+++ b/src/app/webpay-plus-deferred/commit/error/aborted.tsx
@@ -7,6 +7,7 @@ import { getStatusTransaction } from "@/app/lib/webpay-plus/data";
 import { getErrorAbortedSteps } from "../../content/steps/error-aborted";
 import { TBKAbortedResponse } from "@/types/transactions";
 import { getWebpayPlusDeferredOptions } from "@/app/lib/webpay-plus-deferred/data";
+import { CustomError } from "@/components/customError/CustomError";
 
 const actualBread: Route[] = [
   {
@@ -32,6 +33,13 @@ export const AbortedView = async (props: AbortedViewProps) => {
     props.abortedResponse.TBK_TOKEN,
     getWebpayPlusDeferredOptions()
   );
+
+  if ("errorMessage" in statusResponse) {
+    return (
+      <CustomError  errorMessage={statusResponse.errorMessage} actualBread={actualBread}/>
+    );
+  }
+
   return (
     <>
       <Head>

--- a/src/app/webpay-plus/commit/error/aborted.tsx
+++ b/src/app/webpay-plus/commit/error/aborted.tsx
@@ -6,6 +6,7 @@ import { getStatusTRXSteps } from "../../content/steps/status";
 import { getStatusTransaction } from "@/app/lib/webpay-plus/data";
 import { getErrorAbortedSteps } from "../../content/steps/error-aborted";
 import { TBKAbortedResponse } from "@/types/transactions";
+import { CustomError } from "@/components/customError/CustomError";
 
 const actualBread: Route[] = [
   {
@@ -30,6 +31,13 @@ export const AbortedView = async (props: AbortedViewProps) => {
   const statusResponse = await getStatusTransaction(
     props.abortedResponse.TBK_TOKEN
   );
+
+  if ("errorMessage" in statusResponse) {
+    return (
+      <CustomError  errorMessage={statusResponse.errorMessage} actualBread={actualBread}/>
+    );
+  }
+
   return (
     <>
       <Head>


### PR DESCRIPTION
in this PR,

- Added error handling in aborted views.

![Captura de pantalla 2024-12-12 a la(s) 6 29 22 p  m](https://github.com/user-attachments/assets/2b64d7f1-878c-411c-b117-2b7b2841f385)

> Normal flow of purchase cancellation by the user
![Captura de pantalla 2024-12-12 a la(s) 6 30 11 p  m](https://github.com/user-attachments/assets/500cb8a1-4678-4c17-9c4f-a4b2f8a22839)


> Controlled error
![Captura de pantalla 2024-12-12 a la(s) 6 31 24 p  m](https://github.com/user-attachments/assets/4f49c413-e035-4f66-bf8f-94d78f80a018)

