### PR TITLE
fix: change import path for getStatusTransaction in aborted view for webpay-mall-deferred

### DIFF
--- a/src/app/webpay-mall-diferido/commit/error/aborted.tsx
+++ b/src/app/webpay-mall-diferido/commit/error/aborted.tsx
@@ -3,7 +3,7 @@ import { Route } from "@/types/menu";
 import { Layout } from "@/components/layout/Layout";
 import { LayoutContent } from "@/components/layout/LayoutContent";
 import { getStatusTRXSteps } from "../../content/steps/status";
-import { getStatusTransaction } from "@/app/lib/webpay-mall/data";
+import { getStatusTransaction } from "@/app/lib/webpay-mall-diferido/data";
 import { getErrorAbortedSteps } from "../../content/steps/error-aborted";
 import { TBKAbortedResponse } from "@/types/transactions";
 import { CustomError } from "@/components/customError/CustomError";


### PR DESCRIPTION
In this PR,
Change was made in the import path getStatusTransaction for webpay-mall-deferred in aborted view.

> Before change
![Captura de pantalla 2024-12-16 a la(s) 2 40 03 p  m](https://github.com/user-attachments/assets/f56858f6-6433-4921-9d78-13d6156e21b1)

> After change
![Captura de pantalla 2024-12-16 a la(s) 2 30 23 p  m](https://github.com/user-attachments/assets/9099a8d0-a462-47e8-9cfd-ee1019a4483b)
