### PR TITLE
feat: add message in create.tsx for webpay and oneclick

### DIFF
--- a/src/app/oneclick-mall-deferred/content/steps/create.tsx
+++ b/src/app/oneclick-mall-deferred/content/steps/create.tsx
@@ -82,6 +82,18 @@ export const getCreateTRXSteps = (
             &quot;TBK_TOKEN&quot;, el cual es esencial para completar el proceso
             de pago de manera exitosa.
           </Text>
+
+          <Text>
+            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+                <a
+                  className="tbk-link tbk-link-alt"
+                  href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                 documentación.
+                </a>{" "}
+          </Text>
         </div>
       ),
     },

--- a/src/app/oneclick-mall-deferred/content/steps/create.tsx
+++ b/src/app/oneclick-mall-deferred/content/steps/create.tsx
@@ -84,7 +84,7 @@ export const getCreateTRXSteps = (
           </Text>
 
           <Text>
-            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+            Antes de continuar al formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
                 <a
                   className="tbk-link tbk-link-alt"
                   href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"

--- a/src/app/oneclick-mall/content/steps/create.tsx
+++ b/src/app/oneclick-mall/content/steps/create.tsx
@@ -82,6 +82,18 @@ export const getCreateTRXSteps = (
             &quot;TBK_TOKEN&quot;, el cual es esencial para completar el proceso
             de pago de manera exitosa.
           </Text>
+
+          <Text>
+            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+                <a
+                  className="tbk-link tbk-link-alt"
+                  href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                 documentación.
+                </a>{" "}
+          </Text>
         </div>
       ),
     },

--- a/src/app/oneclick-mall/content/steps/create.tsx
+++ b/src/app/oneclick-mall/content/steps/create.tsx
@@ -84,7 +84,7 @@ export const getCreateTRXSteps = (
           </Text>
 
           <Text>
-            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+            Antes de continuar al formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
                 <a
                   className="tbk-link tbk-link-alt"
                   href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"

--- a/src/app/webpay-mall-diferido/content/steps/create.tsx
+++ b/src/app/webpay-mall-diferido/content/steps/create.tsx
@@ -86,7 +86,7 @@ export const getCreateTRXSteps = (
           </Text>
 
           <Text>
-            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+            Antes de continuar al formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
                 <a
                   className="tbk-link tbk-link-alt"
                   href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"

--- a/src/app/webpay-mall-diferido/content/steps/create.tsx
+++ b/src/app/webpay-mall-diferido/content/steps/create.tsx
@@ -84,6 +84,18 @@ export const getCreateTRXSteps = (
             &quot;token_ws&quot;, el cual es esencial para completar el proceso
             de pago de manera exitosa.
           </Text>
+
+          <Text>
+            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+                <a
+                  className="tbk-link tbk-link-alt"
+                  href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                 documentación.
+                </a>{" "}
+          </Text>
         </div>
       ),
     },

--- a/src/app/webpay-mall/content/steps/create.tsx
+++ b/src/app/webpay-mall/content/steps/create.tsx
@@ -86,7 +86,7 @@ export const getCreateTRXSteps = (
           </Text>
 
           <Text>
-            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+            Antes de continuar al formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
                 <a
                   className="tbk-link tbk-link-alt"
                   href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"

--- a/src/app/webpay-mall/content/steps/create.tsx
+++ b/src/app/webpay-mall/content/steps/create.tsx
@@ -84,6 +84,18 @@ export const getCreateTRXSteps = (
             &quot;token_ws&quot;, el cual es esencial para completar el proceso
             de pago de manera exitosa.
           </Text>
+
+          <Text>
+            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+                <a
+                  className="tbk-link tbk-link-alt"
+                  href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                 documentación.
+                </a>{" "}
+          </Text>
         </div>
       ),
     },

--- a/src/app/webpay-plus-deferred/content/steps/create.tsx
+++ b/src/app/webpay-plus-deferred/content/steps/create.tsx
@@ -86,7 +86,7 @@ export const getCreateTRXSteps = (
           </Text>
 
           <Text>
-            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+            Antes de continuar al formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
                 <a
                   className="tbk-link tbk-link-alt"
                   href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"

--- a/src/app/webpay-plus-deferred/content/steps/create.tsx
+++ b/src/app/webpay-plus-deferred/content/steps/create.tsx
@@ -84,6 +84,18 @@ export const getCreateTRXSteps = (
             &quot;token_ws&quot;, el cual es esencial para completar el proceso
             de pago de manera exitosa.
           </Text>
+
+          <Text>
+            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+                <a
+                  className="tbk-link tbk-link-alt"
+                  href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                 documentación.
+                </a>{" "}
+          </Text>
         </div>
       ),
     },

--- a/src/app/webpay-plus/content/steps/create.tsx
+++ b/src/app/webpay-plus/content/steps/create.tsx
@@ -86,7 +86,7 @@ export const getCreateTRXSteps = (
           </Text>
 
           <Text>
-            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+            Antes de continuar al formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
                 <a
                   className="tbk-link tbk-link-alt"
                   href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"

--- a/src/app/webpay-plus/content/steps/create.tsx
+++ b/src/app/webpay-plus/content/steps/create.tsx
@@ -84,6 +84,18 @@ export const getCreateTRXSteps = (
             &quot;token_ws&quot;, el cual es esencial para completar el proceso
             de pago de manera exitosa.
           </Text>
+
+          <Text>
+            Antes de continuar con el formulario de Webpay, asegúrate de contar con los datos de las tarjetas de prueba que están en la{" "}
+                <a
+                  className="tbk-link tbk-link-alt"
+                  href="https://transbankdevelopers.cl/documentacion/como_empezar#tarjetas-de-prueba"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                 documentación.
+                </a>{" "}
+          </Text>
         </div>
       ),
     },


### PR DESCRIPTION
In this PR,
a message has been added before proceeding to the payment form on all products, telling users not to forget to have the test card data before proceeding to the payment or registration phase.

> Before change
![Captura de pantalla 2024-12-16 a la(s) 5 34 52 p  m](https://github.com/user-attachments/assets/57d9889d-aea5-4e9d-8be0-f1ae4c2ccb41)

> After change
![Captura de pantalla 2024-12-16 a la(s) 5 35 11 p  m](https://github.com/user-attachments/assets/4e954cf1-4ded-48ab-b573-2ef4e160f086)
