### PR TITLE
fix: add vci field in tbk commit transaction response

### DIFF
--- a/src/app/webpay-plus/content/snippets/commit.ts
+++ b/src/app/webpay-plus/content/snippets/commit.ts
@@ -14,6 +14,7 @@ const commitResponse = await (new WebpayPlus.Transaction()).commit(token);`;
 
 export const getStepThree = (commitResponse: TBKCommitTransactionResponse) => {
   const {
+    vci,
     amount,
     status,
     buy_order,
@@ -24,9 +25,12 @@ export const getStepThree = (commitResponse: TBKCommitTransactionResponse) => {
     authorization_code,
     payment_type_code,
     response_code,
+    installments_amount,
     installments_number,
+    balance,
   } = commitResponse;
   return `{
+  "vci": "${vci}",
   "amount": ${amount},
   "status": "${status}",
   "buy_order": "${buy_order}",
@@ -39,6 +43,8 @@ export const getStepThree = (commitResponse: TBKCommitTransactionResponse) => {
   "authorization_code": "${authorization_code}",
   "payment_type_code": "${payment_type_code}",
   "response_code": "${response_code}",
+  "installments_amount": ${installments_amount ?? null}
   "installments_number": "${installments_number}"
+  "balance": "${balance}"
   }`;
 };

--- a/src/app/webpay-plus/content/snippets/status.ts
+++ b/src/app/webpay-plus/content/snippets/status.ts
@@ -7,21 +7,37 @@ const statusResponse = await (new WebpayPlus.Transaction()).status(token);`;
 
 export const getStepTwo = (commitResponse: TBKTransactionStatusResponse) => {
   const {
+    vci,
     amount,
     status,
     buy_order,
     session_id,
+    card_detail,
     accounting_date,
     transaction_date,
+    authorization_code,
+    payment_type_code,
+    response_code,
+    installments_amount,
     installments_number,
+    balance,
   } = commitResponse;
   return `{
+  "vci": "${vci}",
   "amount": ${amount},
   "status": "${status}",
   "buy_order": "${buy_order}",
   "session_id": "${session_id}",
+  "card_detail": {
+    "card_number": "${card_detail.card_number}",
+  },
   "accounting_date": "${accounting_date}",
   "transaction_date": "${transaction_date}",
+  "authorization_code": "${authorization_code}",
+  "payment_type_code": "${payment_type_code}",
+  "response_code": "${response_code}",
+  "installments_amount": ${installments_amount ?? null}
   "installments_number": "${installments_number}"
+  "balance": ${balance ?? null}
   }`;
 };

--- a/src/types/transactions.tsx
+++ b/src/types/transactions.tsx
@@ -88,6 +88,7 @@ export enum PaymentTypeCode {
 }
 
 export type TBKCommitTransactionResponse = {
+  vci: string,
   amount: number;
   status: TBKTransactionStatus;
   buy_order: string;
@@ -98,8 +99,13 @@ export type TBKCommitTransactionResponse = {
   authorization_code: string;
   payment_type_code: PaymentTypeCode;
   response_code: number;
+  installments_amount: number;
   installments_number: number;
+  balance: number;
 };
+
+export type TBKTransactionStatusResponse = TBKCommitTransactionResponse;
+
 export type TBKPatpassStatusTxResponse = {
   authorized: string;
   voucherUrl: string;
@@ -147,11 +153,6 @@ export type TBKfullTxCaptureResponse = {
   captured_amount: number;
   response_code: number;
 };
-
-export type TBKTransactionStatusResponse = Omit<
-  TBKCommitTransactionResponse,
-  "card_detail" | "authorization_code" | "payment_type_code" | "response_code"
->;
 
 export type TBKMallTransactionStatusResponse = {
   details: TransactionDetail[];


### PR DESCRIPTION
This PR add missing fields in commit response for webpay.

## Test

### Before
![image](https://github.com/user-attachments/assets/b62241ca-08b3-4da4-b391-6bda35ef1ece)

### After
<img width="1297" alt="image" src="https://github.com/user-attachments/assets/ce5e1d8f-63e6-4b1e-b308-f408a60e10d9" />
