### PR TITLE
fix: add protections in webpay responses

### DIFF
--- a/src/app/webpay-plus/content/snippets/commit.ts
+++ b/src/app/webpay-plus/content/snippets/commit.ts
@@ -30,21 +30,21 @@ export const getStepThree = (commitResponse: TBKCommitTransactionResponse) => {
     balance,
   } = commitResponse;
   return `{
-  "vci": "${vci ?? null}",
+  "vci": ${vci ? `"${vci}"` : null},
   "amount": ${amount ?? null},
-  "status": "${status ?? null}",
-  "buy_order": "${buy_order ?? null}",
-  "session_id": "${session_id ?? null}",
+  "status": ${status ? `"${status}"` : null},
+  "buy_order": ${buy_order ? `"${buy_order}"` : null},
+  "session_id": ${session_id ? `"${session_id}"` : null},
   "card_detail": {
-    "card_number": "${card_detail?.card_number ?? null}",
+    "card_number": ${card_detail?.card_number ? `"${card_detail.card_number}"` : null}
   },
-  "accounting_date": "${accounting_date ?? null}",
-  "transaction_date": "${transaction_date ?? null}",
-  "authorization_code": "${authorization_code ?? null}",
-  "payment_type_code": "${payment_type_code ?? null}",
+  "accounting_date": ${accounting_date ? `"${accounting_date}"` : null},
+  "transaction_date": ${transaction_date ? `"${transaction_date}"` : null},
+  "authorization_code": ${authorization_code ? `"${authorization_code}"` : null},
+  "payment_type_code": ${payment_type_code ? `"${payment_type_code}"` : null},
   "response_code": ${response_code ?? null},
-  "installments_amount": ${installments_amount ?? null}
-  "installments_number": ${installments_number ?? null}
+  "installments_amount": ${installments_amount ?? null},
+  "installments_number": ${installments_number ?? null},
   "balance": ${balance ?? null}
-  }`;
+}`;
 };

--- a/src/app/webpay-plus/content/snippets/commit.ts
+++ b/src/app/webpay-plus/content/snippets/commit.ts
@@ -30,21 +30,21 @@ export const getStepThree = (commitResponse: TBKCommitTransactionResponse) => {
     balance,
   } = commitResponse;
   return `{
-  "vci": "${vci}",
-  "amount": ${amount},
-  "status": "${status}",
-  "buy_order": "${buy_order}",
-  "session_id": "${session_id}",
+  "vci": "${vci ?? null}",
+  "amount": ${amount ?? null},
+  "status": "${status ?? null}",
+  "buy_order": "${buy_order ?? null}",
+  "session_id": "${session_id ?? null}",
   "card_detail": {
-    "card_number": "${card_detail.card_number}",
+    "card_number": "${card_detail?.card_number ?? null}",
   },
-  "accounting_date": "${accounting_date}",
-  "transaction_date": "${transaction_date}",
-  "authorization_code": "${authorization_code}",
-  "payment_type_code": "${payment_type_code}",
-  "response_code": "${response_code}",
+  "accounting_date": "${accounting_date ?? null}",
+  "transaction_date": "${transaction_date ?? null}",
+  "authorization_code": "${authorization_code ?? null}",
+  "payment_type_code": "${payment_type_code ?? null}",
+  "response_code": ${response_code ?? null},
   "installments_amount": ${installments_amount ?? null}
-  "installments_number": "${installments_number}"
-  "balance": "${balance}"
+  "installments_number": ${installments_number ?? null}
+  "balance": ${balance ?? null}
   }`;
 };

--- a/src/app/webpay-plus/content/snippets/status.ts
+++ b/src/app/webpay-plus/content/snippets/status.ts
@@ -23,21 +23,21 @@ export const getStepTwo = (commitResponse: TBKTransactionStatusResponse) => {
     balance,
   } = commitResponse;
   return `{
-  "vci": "${vci ?? null}",
+  "vci": ${vci ? `"${vci}"` : null},
   "amount": ${amount ?? null},
-  "status": "${status ?? null}",
-  "buy_order": "${buy_order ?? null}",
-  "session_id": "${session_id ?? null}",
+  "status": ${status ? `"${status}"` : null},
+  "buy_order": ${buy_order ? `"${buy_order}"` : null},
+  "session_id": ${session_id ? `"${session_id}"` : null},
   "card_detail": {
-    "card_number": "${card_detail?.card_number ?? null}",
+    "card_number": ${card_detail?.card_number ? `"${card_detail.card_number}"` : null}
   },
-  "accounting_date": "${accounting_date ?? null}",
-  "transaction_date": "${transaction_date ?? null}",
-  "authorization_code": "${authorization_code ?? null}",
-  "payment_type_code": "${payment_type_code ?? null}",
+  "accounting_date": ${accounting_date ? `"${accounting_date}"` : null},
+  "transaction_date": ${transaction_date ? `"${transaction_date}"` : null},
+  "authorization_code": ${authorization_code ? `"${authorization_code}"` : null},
+  "payment_type_code": ${payment_type_code ? `"${payment_type_code}"` : null},
   "response_code": ${response_code ?? null},
-  "installments_amount": ${installments_amount ?? null}
-  "installments_number": ${installments_number ?? null}
+  "installments_amount": ${installments_amount ?? null},
+  "installments_number": ${installments_number ?? null},
   "balance": ${balance ?? null}
-  }`;
+}`;
 };

--- a/src/app/webpay-plus/content/snippets/status.ts
+++ b/src/app/webpay-plus/content/snippets/status.ts
@@ -23,21 +23,21 @@ export const getStepTwo = (commitResponse: TBKTransactionStatusResponse) => {
     balance,
   } = commitResponse;
   return `{
-  "vci": "${vci}",
-  "amount": ${amount},
-  "status": "${status}",
-  "buy_order": "${buy_order}",
-  "session_id": "${session_id}",
+  "vci": "${vci ?? null}",
+  "amount": ${amount ?? null},
+  "status": "${status ?? null}",
+  "buy_order": "${buy_order ?? null}",
+  "session_id": "${session_id ?? null}",
   "card_detail": {
-    "card_number": "${card_detail.card_number}",
+    "card_number": "${card_detail?.card_number ?? null}",
   },
-  "accounting_date": "${accounting_date}",
-  "transaction_date": "${transaction_date}",
-  "authorization_code": "${authorization_code}",
-  "payment_type_code": "${payment_type_code}",
-  "response_code": "${response_code}",
+  "accounting_date": "${accounting_date ?? null}",
+  "transaction_date": "${transaction_date ?? null}",
+  "authorization_code": "${authorization_code ?? null}",
+  "payment_type_code": "${payment_type_code ?? null}",
+  "response_code": ${response_code ?? null},
   "installments_amount": ${installments_amount ?? null}
-  "installments_number": "${installments_number}"
+  "installments_number": ${installments_number ?? null}
   "balance": ${balance ?? null}
   }`;
 };


### PR DESCRIPTION
This PR add protections for commit and status response.

## Test
![image](https://github.com/user-attachments/assets/5b9f4fb3-ef59-4e4b-895b-7c42f2b8e5e0)

![image](https://github.com/user-attachments/assets/b149da21-fdfa-4004-a0a1-0731f1ae7b95)
