### PR TITLE
fix: remove incoherent text in status operation.

### DIFF
--- a/src/app/api-reference/transaccion-completa-diferido/page.tsx
+++ b/src/app/api-reference/transaccion-completa-diferido/page.tsx
@@ -30,8 +30,7 @@ export default function ApiRefWebpay() {
 
         <h2 id="api-status">Obtener estado de una transacción</h2>
         <p>
-          Esta operación permite obtener el estado de la transacción en
-          cualquier momento. En condiciones normales es probable que no se
+          En condiciones normales es probable que no se
           requiera ejecutar, pero en caso de ocurrir un error inesperado permite
           conocer el estado y tomar las acciones que correspondan. La consulta
           de estado se puede realizar hasta 7 días desde la creación de la

--- a/src/app/api-reference/transaccion-completa-mall-diferido/page.tsx
+++ b/src/app/api-reference/transaccion-completa-mall-diferido/page.tsx
@@ -30,8 +30,7 @@ export default function ApiRefWebpayMall() {
 
         <h2 id="api-status">Obtener estado de una transacción</h2>
         <p>
-          Esta operación permite obtener el estado de la transacción en
-          cualquier momento. En condiciones normales es probable que no se
+          En condiciones normales es probable que no se
           requiera ejecutar, pero en caso de ocurrir un error inesperado permite
           conocer el estado y tomar las acciones que correspondan. La consulta
           de estado se puede realizar hasta 7 días desde la creación de la

--- a/src/app/api-reference/transaccion-completa-mall/page.tsx
+++ b/src/app/api-reference/transaccion-completa-mall/page.tsx
@@ -28,8 +28,7 @@ export default function ApiRefWebpayMall() {
 
         <h2 id="api-status">Obtener estado de una transacción</h2>
         <p>
-          Esta operación permite obtener el estado de la transacción en
-          cualquier momento. En condiciones normales es probable que no se
+          En condiciones normales es probable que no se
           requiera ejecutar, pero en caso de ocurrir un error inesperado permite
           conocer el estado y tomar las acciones que correspondan. La consulta
           de estado se puede realizar hasta 7 días desde la creación de la

--- a/src/app/api-reference/transaccion-completa/page.tsx
+++ b/src/app/api-reference/transaccion-completa/page.tsx
@@ -28,8 +28,7 @@ export default function ApiRefWebpay() {
 
         <h2 id="api-status">Obtener estado de una transacción</h2>
         <p>
-          Esta operación permite obtener el estado de la transacción en
-          cualquier momento. En condiciones normales es probable que no se
+          En condiciones normales es probable que no se
           requiera ejecutar, pero en caso de ocurrir un error inesperado permite
           conocer el estado y tomar las acciones que correspondan. La consulta
           de estado se puede realizar hasta 7 días desde la creación de la

--- a/src/app/api-reference/webpay-mall-deferred/page.tsx
+++ b/src/app/api-reference/webpay-mall-deferred/page.tsx
@@ -29,8 +29,7 @@ export default function ApiRefWebpayMall() {
         </p>
         <h2 id="api-status">Obtener estado de una transacción</h2>
         <p>
-          Esta operación permite obtener el estado de la transacción en
-          cualquier momento. En condiciones normales es probable que no se
+          En condiciones normales es probable que no se
           requiera ejecutar, pero en caso de ocurrir un error inesperado permite
           conocer el estado y tomar las acciones que correspondan. La consulta
           de estado se puede realizar hasta 7 días desde la creación de la

--- a/src/app/api-reference/webpay-mall/page.tsx
+++ b/src/app/api-reference/webpay-mall/page.tsx
@@ -28,8 +28,7 @@ export default function ApiRefWebpayMall() {
 
         <h2 id="api-status">Obtener estado de una transacción</h2>
         <p>
-          Esta operación permite obtener el estado de la transacción en
-          cualquier momento. En condiciones normales es probable que no se
+          En condiciones normales es probable que no se
           requiera ejecutar, pero en caso de ocurrir un error inesperado permite
           conocer el estado y tomar las acciones que correspondan. La consulta
           de estado se puede realizar hasta 7 días desde la creación de la

--- a/src/app/api-reference/webpay-plus-deferred/page.tsx
+++ b/src/app/api-reference/webpay-plus-deferred/page.tsx
@@ -29,8 +29,7 @@ export default function ApiRefWebpayDeferred() {
         </p>
         <h2 id="api-status">Obtener estado de una transacción</h2>
         <p>
-          Esta operación permite obtener el estado de la transacción en
-          cualquier momento. En condiciones normales es probable que no se
+          En condiciones normales es probable que no se
           requiera ejecutar, pero en caso de ocurrir un error inesperado permite
           conocer el estado y tomar las acciones que correspondan. La consulta
           de estado se puede realizar hasta 7 días desde la creación de la

--- a/src/app/api-reference/webpay-plus/page.tsx
+++ b/src/app/api-reference/webpay-plus/page.tsx
@@ -27,8 +27,7 @@ export default function ApiRefWebpay() {
         </p>
         <h2 id="api-status">Obtener estado de una transacción</h2>
         <p>
-          Esta operación permite obtener el estado de la transacción en
-          cualquier momento. En condiciones normales es probable que no se
+          En condiciones normales es probable que no se
           requiera ejecutar, pero en caso de ocurrir un error inesperado permite
           conocer el estado y tomar las acciones que correspondan. La consulta
           de estado se puede realizar hasta 7 días desde la creación de la


### PR DESCRIPTION
This PR remove incoherent text from status operation section.

## Test
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/579deb67-ee19-4bfd-aed9-c4d21c3a2c5a" />
