### PR TITLE
docs: snippets update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^18.3.1",
         "react-syntax-highlighter": "^15.6.1",
         "tailwindcss": "^3.4.17",
-        "transbank-sdk": "^5.0.0"
+        "transbank-sdk": "^6.0.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4797,11 +4797,12 @@
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/transbank-sdk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/transbank-sdk/-/transbank-sdk-5.0.0.tgz",
-      "integrity": "sha512-hHvkPPSkcIZpjrFtwGhFfG6HNLstxDv4PLLsuRtiKuadA6o7Vd8P74XmFUub31MClIGmF2h+aGMj4ZO7XoT1RQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/transbank-sdk/-/transbank-sdk-6.0.0.tgz",
+      "integrity": "sha512-Tw0N5kQZQVNSoToETsGfNdOVCf4TMGb7cTx/Rc0Dbt5k1tHTRoxeFKYF/vI6bR6+/TVUgHR26DL/mXUDqd4QDw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "axios": "^1.6.5"
+        "axios": "^1.8.3"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^18.3.1",
     "react-syntax-highlighter": "^15.6.1",
     "tailwindcss": "^3.4.17",
-    "transbank-sdk": "^5.0.0"
+    "transbank-sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/lib/patpass-comercio/data.ts
+++ b/src/app/lib/patpass-comercio/data.ts
@@ -8,6 +8,7 @@ import {
   Options,
   IntegrationCommerceCodes,
   IntegrationApiKeys,
+  PatpassEnvironment,
   PatpassComercio,
 } from "transbank-sdk";
 
@@ -15,7 +16,7 @@ export const getPatpassOptions = () => {
   return new Options(
     IntegrationCommerceCodes.PATPASS_COMERCIO,
     IntegrationApiKeys.PATPASS_COMERCIO,
-    "https://pagoautomaticocontarjetasint.transbank.cl"
+    PatpassEnvironment.Integration
   );
 };
 

--- a/src/app/oneclick-mall-deferred/content/PageContent.tsx
+++ b/src/app/oneclick-mall-deferred/content/PageContent.tsx
@@ -2,7 +2,7 @@
 import { CardPay, TokenPropNames } from "@/components/cardpay/CardPay";
 import { Layout } from "@/components/layout/Layout";
 import Head from "next/head";
-import { getCreateTRXSteps } from "../../oneclick-mall/content/steps/create";
+import { getCreateTRXSteps } from "../../oneclick-mall-deferred/content/steps/create";
 import { CreateTransactionResult } from "@/app/lib/oneclick-mall/data";
 import { Route } from "@/types/menu";
 import { NavigationItem } from "@/components/layout/Navigation";

--- a/src/app/oneclick-mall-deferred/content/snippets/authorize.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/authorize.ts
@@ -1,8 +1,11 @@
 import { TBKAuthorizeTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const Oneclick = require('transbank-sdk').Oneclick; // CommonJS
-import { Oneclick } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new Oneclick.MallTransaction(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 const details = [
   new TransactionDetail(amount, childCommerceCode, childBuyOrder), 
@@ -10,9 +13,9 @@ const details = [
 )];
 
 // Es necesario ejecutar dentro de una función async para utilizar await
-const authorizeResponse = await (new Oneclick.MallTransaction()).authorize(
+const authorizeResponse = await tx.authorize(
   username, 
-  tbkUser, 
+  tbk_user, 
   buyOrder,
   details
 );`;

--- a/src/app/oneclick-mall-deferred/content/snippets/authorize.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/authorize.ts
@@ -8,8 +8,8 @@ export const getStepOne = () => {
 ));
 
 const details = [
-  new TransactionDetail(amount, childCommerceCode, childBuyOrder), 
-  new TransactionDetail(amount2, childCommerceCode2, childBuyOrder2)
+  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1), 
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2)
 )];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/oneclick-mall-deferred/content/snippets/capture.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/capture.ts
@@ -1,7 +1,7 @@
 import { TBKCaptureTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = (token: string) => {
-  return `//buyOrderTienda: ${token}
+  return `//buyOrderStore: ${token}
 
 const tx = new Oneclick.MallTransaction(new Options(
   IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,

--- a/src/app/oneclick-mall-deferred/content/snippets/capture.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/capture.ts
@@ -1,7 +1,7 @@
 import { TBKCaptureTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = (token: string) => {
-  return `//childBuyOrder: ${token}
+  return `//buyOrderTienda: ${token}
 
 const tx = new Oneclick.MallTransaction(new Options(
   IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
@@ -11,7 +11,7 @@ const tx = new Oneclick.MallTransaction(new Options(
 
 const captureResponse = await tx.capture(
   commerceCode,
-  childBuyOrder,
+  buyOrderStore,
   authorizationCode,
   captureAmount
 );`;

--- a/src/app/oneclick-mall-deferred/content/snippets/capture.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/capture.ts
@@ -1,10 +1,17 @@
 import { TBKCaptureTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = (token: string) => {
-  return `//buyOrder: ${token}
-  const captureResponse = await (new WebpayPlus.Transaction()).capture(
+  return `//childBuyOrder: ${token}
+
+const tx = new Oneclick.MallTransaction(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const captureResponse = await tx.capture(
   commerceCode,
-  buyOrder,
+  childBuyOrder,
   authorizationCode,
   captureAmount
 );`;

--- a/src/app/oneclick-mall-deferred/content/snippets/create.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/create.ts
@@ -1,19 +1,32 @@
 export const getStepOne = () => {
-  return `const WebpayPlus = require('transbank-sdk').WebpayPlus; // ES5
-const TransactionDetail = require("transbank-sdk").TransactionDetail;
+  return `const {
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Oneclick,
+Options,
+TransactionDetail
+} = require('transbank-sdk'); // ES5
 
-import { WebpayPlus, TransactionDetail } from 'transbank-sdk'; // ES6
+import { 
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Oneclick,
+Options,
+TransactionDetail 
+} from 'transbank-sdk'; // ES6
 
-const details = [
-  new TransactionDetail(135, "597055555536", "O-23101"),
-  new TransactionDetail(148, "597055555536", "O-10821"),
-]
+const tx = new Oneclick.MallInscription(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
-const createResponse = await (new WebpayPlus.MallTransaction()).create(
-  buyOrder, 
-  sessionId, 
-  returnUrl,
-  details
+const createResponse = await tx.start(
+  userName,
+  email,
+  returnUrl
 );`;
 };
 

--- a/src/app/oneclick-mall-deferred/content/snippets/finish.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/finish.ts
@@ -7,9 +7,15 @@ export const getStepOne = (token: string) => {
 };
 
 export const getStepTwo = () => {
-  return `// En el caso de Express
-let token = request.body.TBK_TOKEN;
-const commitResponse = await (new Oneclick.MallInscription()).finish(token);`;
+  return `const token = request.body.TBK_TOKEN;
+
+const tx = new Oneclick.MallInscription(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const commitResponse = await tx.finish(token);`;
 };
 
 export const getStepThree = (

--- a/src/app/oneclick-mall-deferred/content/snippets/refund.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/refund.ts
@@ -12,8 +12,8 @@ const tx = new Oneclick.MallTransaction(new Options(
 
 const refundRequest = await tx.refund(
   buyOrder,
-  childCommerceCode,
-  childBuyOrder,
+  commerceCodeStore,
+  buyOrderStore,
   amount
 );`;
 };

--- a/src/app/oneclick-mall-deferred/content/snippets/refund.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/refund.ts
@@ -4,7 +4,13 @@ export const getStepOne = (buyOrder: string, amount: string) => {
   return `// BuyOrder: ${buyOrder}
 // Amount: ${amount}
 
-const refundRequest = await (new Oneclick.MallTransaction()).refund(
+const tx = new Oneclick.MallTransaction(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const refundRequest = await tx.refund(
   buyOrder,
   childCommerceCode,
   childBuyOrder,

--- a/src/app/oneclick-mall-deferred/content/snippets/remove-user.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/remove-user.ts
@@ -1,3 +1,12 @@
 export const getStepOne = (tbkUser: string, userName: string) => {
-  return `await (new Oneclick.MallInscription()).delete("${tbkUser}", "${userName}");`;
+  return `//tbkUser: ${tbkUser}
+//userName ${userName}
+
+const tx = new Oneclick.MallInscription(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+  
+await tx.delete("${tbkUser}", "${userName}");`;
 };

--- a/src/app/oneclick-mall-deferred/content/snippets/status.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/status.ts
@@ -1,9 +1,15 @@
 import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (buyOrder: string) => {
-  return `// BuyOrder: 
-const buyOrder = "${buyOrder}";
-const statusResponse = await (new Oneclick.MallTransaction()).status(buyOrder);`;
+  return `const buyOrder = "${buyOrder}";
+
+const tx = new Oneclick.MallTransaction(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const statusResponse = await tx.status(buyOrder);`;
 };
 
 export const getStepTwo = (statusResponse: TBKMallTransactionStatusResponse) =>

--- a/src/app/oneclick-mall-deferred/content/steps/authorize.tsx
+++ b/src/app/oneclick-mall-deferred/content/steps/authorize.tsx
@@ -1,6 +1,6 @@
 import { StepProps } from "@/components/step/Step";
 import { TBKAuthorizeTransactionResponse } from "@/types/transactions";
-import * as authorizeSnippets from "@/app/oneclick-mall/content/snippets/authorize";
+import * as authorizeSnippets from "@/app/oneclick-mall-deferred/content/snippets/authorize";
 import { Text } from "@/components/text/Text";
 import { OkAuthorizeMessage } from "@/components/messages/OkAuthorizeMessage";
 

--- a/src/app/oneclick-mall-deferred/content/steps/create.tsx
+++ b/src/app/oneclick-mall-deferred/content/steps/create.tsx
@@ -1,6 +1,6 @@
 import { StepProps } from "@/components/step/Step";
 import { StartTransactionDataOneclickMall } from "@/types/transactions";
-import * as createSnippets from "@/app/oneclick-mall/content/snippets/create";
+import * as createSnippets from "@/app/oneclick-mall-deferred/content/snippets/create";
 import { Table } from "@/components/table/Table";
 import {
   getColumnDefinition,

--- a/src/app/oneclick-mall-deferred/content/steps/finish.tsx
+++ b/src/app/oneclick-mall-deferred/content/steps/finish.tsx
@@ -1,6 +1,6 @@
 import { StepProps } from "@/components/step/Step";
 import { TBKFinishInscriptionResponse } from "@/types/transactions";
-import * as finishInscriptionSnippets from "@/app/oneclick-mall/content/snippets/finish";
+import * as finishInscriptionSnippets from "@/app/oneclick-mall-deferred/content/snippets/finish";
 import { Table } from "@/components/table/Table";
 import {
   getColumnDefinition,

--- a/src/app/oneclick-mall-deferred/content/steps/refund.tsx
+++ b/src/app/oneclick-mall-deferred/content/steps/refund.tsx
@@ -1,5 +1,5 @@
 import { StepProps } from "@/components/step/Step";
-import * as refundSnippets from "@/app/oneclick-mall/content/snippets/refund";
+import * as refundSnippets from "@/app/oneclick-mall-deferred/content/snippets/refund";
 import { Text } from "@/components/text/Text";
 import { TBKRefundMallTransactionResponse } from "@/types/transactions";
 

--- a/src/app/oneclick-mall-deferred/content/steps/remove-user.tsx
+++ b/src/app/oneclick-mall-deferred/content/steps/remove-user.tsx
@@ -1,5 +1,5 @@
 import { StepProps } from "@/components/step/Step";
-import * as removeUserSnippets from "@/app/oneclick-mall/content/snippets/remove-user";
+import * as removeUserSnippets from "@/app/oneclick-mall-deferred/content/snippets/remove-user";
 import { Text, TextVariant } from "@/components/text/Text";
 
 export const getRemoveUserSteps = (

--- a/src/app/oneclick-mall-deferred/content/steps/status.tsx
+++ b/src/app/oneclick-mall-deferred/content/steps/status.tsx
@@ -1,6 +1,6 @@
 import { StepProps } from "@/components/step/Step";
 import { TBKMallTransactionStatusResponse } from "@/types/transactions";
-import * as statusSnippets from "@/app/oneclick-mall/content/snippets/status";
+import * as statusSnippets from "@/app/oneclick-mall-deferred/content/snippets/status";
 import { Text } from "@/components/text/Text";
 
 export const getStatusTRXSteps = (

--- a/src/app/oneclick-mall-deferred/refund/page.tsx
+++ b/src/app/oneclick-mall-deferred/refund/page.tsx
@@ -2,7 +2,7 @@ import "./page.css";
 import { Route } from "@/types/menu";
 import { Layout } from "@/components/layout/Layout";
 import Head from "next/head";
-import { getRefundTRXSteps } from "@/app/oneclick-mall/content/steps/refund";
+import { getRefundTRXSteps } from "@/app/oneclick-mall-deferred/content/steps/refund";
 import { NextPageProps } from "@/types/general";
 import { refundOneClickMallTransaction } from "@/app/lib/oneclick-mall/data";
 import { CustomError } from "@/components/customError/CustomError";

--- a/src/app/oneclick-mall-deferred/status/page.tsx
+++ b/src/app/oneclick-mall-deferred/status/page.tsx
@@ -1,7 +1,7 @@
 import { Route } from "@/types/menu";
 import { Layout } from "@/components/layout/Layout";
 import Head from "next/head";
-import { getStatusTRXSteps } from "@/app/oneclick-mall/content/steps/status";
+import { getStatusTRXSteps } from "@/app/oneclick-mall-deferred/content/steps/status";
 import { NextPageProps } from "@/types/general";
 import { NavigationItem } from "@/components/layout/Navigation";
 import { getStatusOneclickMallTransaction } from "@/app/lib/oneclick-mall/data";

--- a/src/app/oneclick-mall/content/snippets/authorize.ts
+++ b/src/app/oneclick-mall/content/snippets/authorize.ts
@@ -1,8 +1,11 @@
 import { TBKAuthorizeTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const Oneclick = require('transbank-sdk').Oneclick; // CommonJS
-import { Oneclick } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new Oneclick.MallTransaction(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 const details = [
   new TransactionDetail(amount, childCommerceCode, childBuyOrder), 
@@ -10,7 +13,7 @@ const details = [
 )];
 
 // Es necesario ejecutar dentro de una función async para utilizar await
-const authorizeResponse = await (new Oneclick.MallTransaction()).authorize(
+const authorizeResponse = await tx.authorize(
   username, 
   tbkUser, 
   buyOrder,

--- a/src/app/oneclick-mall/content/snippets/authorize.ts
+++ b/src/app/oneclick-mall/content/snippets/authorize.ts
@@ -8,8 +8,8 @@ export const getStepOne = () => {
 ));
 
 const details = [
-  new TransactionDetail(amount, childCommerceCode, childBuyOrder), 
-  new TransactionDetail(amount2, childCommerceCode2, childBuyOrder2)
+  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1), 
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2)
 )];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/oneclick-mall/content/snippets/create.ts
+++ b/src/app/oneclick-mall/content/snippets/create.ts
@@ -23,7 +23,7 @@ const tx = new Oneclick.MallInscription(new Options(
   Environment.Integration
 ));
 
-const startResponse = await (new Oneclick.MallInscription()).start(
+const startResponse = await tx.start(
   userName, 
   email, 
   returnUrl

--- a/src/app/oneclick-mall/content/snippets/create.ts
+++ b/src/app/oneclick-mall/content/snippets/create.ts
@@ -1,6 +1,27 @@
 export const getStepOne = () => {
-  return `const Oneclick = require('transbank-sdk').Oneclick; // ES5
-import { Oneclick } from 'transbank-sdk'; // ES6
+  return `const {
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Oneclick,
+Options,
+TransactionDetail
+} = require('transbank-sdk'); // ES5
+
+import { 
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Oneclick,
+Options,
+TransactionDetail 
+} from 'transbank-sdk'; // ES6
+
+const tx = new Oneclick.MallInscription(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 const startResponse = await (new Oneclick.MallInscription()).start(
   userName, 

--- a/src/app/oneclick-mall/content/snippets/finish.ts
+++ b/src/app/oneclick-mall/content/snippets/finish.ts
@@ -7,9 +7,15 @@ export const getStepOne = (token: string) => {
 };
 
 export const getStepTwo = () => {
-  return `// En el caso de Express
-let token = request.body.TBK_TOKEN;
-const commitResponse = await (new Oneclick.MallInscription()).finish(token);`;
+  return `const token = request.body.TBK_TOKEN;
+
+const tx = new Oneclick.MallInscription(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const commitResponse = await tx.finish(token);`;
 };
 
 export const getStepThree = (

--- a/src/app/oneclick-mall/content/snippets/refund.ts
+++ b/src/app/oneclick-mall/content/snippets/refund.ts
@@ -12,9 +12,9 @@ const tx = new Oneclick.MallTransaction(new Options(
 
 const refundRequest = await tx.refund(
   buyOrder,
-  childCommerceCode,
-  childBuyOrder,
-  amount
+  commerceCodeStore,
+  buyOrderStore,
+  amount
 );`;
 };
 

--- a/src/app/oneclick-mall/content/snippets/refund.ts
+++ b/src/app/oneclick-mall/content/snippets/refund.ts
@@ -4,7 +4,13 @@ export const getStepOne = (buyOrder: string, amount: string) => {
   return `// BuyOrder: ${buyOrder}
 // Amount: ${amount}
 
-const refundRequest = await (new Oneclick.MallTransaction()).refund(
+const tx = new Oneclick.MallTransaction(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const refundRequest = await tx.refund(
   buyOrder,
   childCommerceCode,
   childBuyOrder,

--- a/src/app/oneclick-mall/content/snippets/remove-user.ts
+++ b/src/app/oneclick-mall/content/snippets/remove-user.ts
@@ -1,3 +1,12 @@
 export const getStepOne = (tbkUser: string, userName: string) => {
-  return `await (new Oneclick.MallInscription()).delete("${tbkUser}", "${userName}");`;
+  return `//tbkUser: ${tbkUser}
+//userName: ${userName}
+
+const tx = new Oneclick.MallInscription(
+  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+);
+  
+await tx.delete("${tbkUser}", "${userName}");`;
 };

--- a/src/app/oneclick-mall/content/snippets/status.ts
+++ b/src/app/oneclick-mall/content/snippets/status.ts
@@ -1,9 +1,13 @@
 import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (buyOrder: string) => {
-  return `// BuyOrder: 
-const buyOrder = "${buyOrder}";
-const statusResponse = await (new Oneclick.MallTransaction()).status(buyOrder);`;
+  return `const buyOrder = "${buyOrder}";
+const tx = new Oneclick.MallTransaction(new Options(
+  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const statusResponse = await tx.status(buyOrder);`;
 };
 
 export const getStepTwo = (statusResponse: TBKMallTransactionStatusResponse) =>

--- a/src/app/patpass-comercio/content/snippets/commit.ts
+++ b/src/app/patpass-comercio/content/snippets/commit.ts
@@ -8,7 +8,14 @@ export const getStepOne = (token: string) => {
 
 export const getStepTwo = () => {
   return `let token = request.body.J_TOKEN;
-const resp = await new PatpassComercio.Inscription().status(token);`;
+  
+const tx = new PatpassComercio.Inscription(new Options(
+  IntegrationCommerceCodes.PATPASS_COMERCIO,
+  IntegrationApiKeys.PATPASS_COMERCIO,
+  PatpassEnvironment.Integration
+));
+
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepThree = (commitResponse: TBKPatpassStatusTxResponse) => {

--- a/src/app/patpass-comercio/content/snippets/start.ts
+++ b/src/app/patpass-comercio/content/snippets/start.ts
@@ -1,22 +1,41 @@
 export const getStepOne = () => {
-  return `const startResponse = await (new PatpassComercio.Inscription()).start(
-  userName, 
-  email, 
-  responseUrl
-  url, 
-  name, 
-  lastName, 
-  secondLastName, 
-  rut, 
-  serviceId, 
-  finalUrl, 
-  maxAmount, 
-  phone, 
-  cellPhone, 
-  patpassName, 
-  personEmail, 
-  commerceEmail, 
-  address, 
+  return `const {
+Options,
+IntegrationCommerceCodes,
+IntegrationApiKeys,
+PatpassEnvironment,
+PatpassComercio
+} = require('transbank-sdk'); // ES5
+  
+import {
+Options,
+IntegrationCommerceCodes,
+IntegrationApiKeys,
+PatpassEnvironment,
+PatpassComercio
+} from "transbank-sdk" // ES6
+
+const tx = new PatpassComercio.Inscription(new Options(
+  IntegrationCommerceCodes.PATPASS_COMERCIO,
+  IntegrationApiKeys.PATPASS_COMERCIO,
+  PatpassEnvironment.Integration
+));
+  
+const startResponse = await tx.start(
+  returnUrl,
+  name,
+  lastName,
+  secondLastName,
+  rut,
+  serviceId,
+  finalUrl,
+  maxAmount,
+  phone,
+  cellPhone,
+  patpassName,
+  personEmail,
+  commerceEmail,
+  address,
   city
 );`;
 };

--- a/src/app/transaccion-completa-diferido/content/snippets/capture.tsx
+++ b/src/app/transaccion-completa-diferido/content/snippets/capture.tsx
@@ -1,10 +1,13 @@
 import { TBKfullTxCaptureResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-import { TransaccionCompleta } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
-const resp = await (new TransaccionCompleta.Transaction()).capture(
+const resp = await tx.capture(
   token,
   buyOrder,
   authorizationCode,

--- a/src/app/transaccion-completa-diferido/content/snippets/commit.ts
+++ b/src/app/transaccion-completa-diferido/content/snippets/commit.ts
@@ -1,10 +1,13 @@
 import { TBKFullTxCommitResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-import { TransaccionCompleta } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
-const commitResponse = await (new TransaccionCompleta.Transaction()).commit(
+const commitResponse = await tx.commit(
   token,
   idQueryInstallments,(opcional)
   deferred_period_index, (opcional)

--- a/src/app/transaccion-completa-diferido/content/snippets/create.ts
+++ b/src/app/transaccion-completa-diferido/content/snippets/create.ts
@@ -1,9 +1,28 @@
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // ES5
-import { TransaccionCompleta } from 'transbank-sdk'; // ES6
+  return `const {
+Options,
+IntegrationCommerceCodes,
+IntegrationApiKeys,
+Environment,
+TransaccionCompleta
+} = require('transbank-sdk'); // ES5
+
+import { 
+Options,
+IntegrationCommerceCodes,
+IntegrationApiKeys,
+Environment,
+TransaccionCompleta 
+} from 'transbank-sdk'; // ES6
+
+const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_DEFERRED,
+  IntergationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 // Es necesario ejecutar dentro de una función async para utilizar await
-const createResponse = await (new TransaccionCompleta.Transaction()).create(
+const createResponse = await tx.create(
   buyOrder, 
   sessionId, 
   amount, 

--- a/src/app/transaccion-completa-diferido/content/snippets/installments.tsx
+++ b/src/app/transaccion-completa-diferido/content/snippets/installments.tsx
@@ -1,9 +1,12 @@
 import { InstallmentsFullTXResponse } from "@/types/transactions";
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // ES5
-import { TransaccionCompleta } from 'transbank-sdk'; // ES6
+  return `const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
-const installmentsResponse = await (new TransaccionCompleta.Transaction()).installments(
+const installmentsResponse = await tx.installments(
   token, 
   installments, 
 );`;

--- a/src/app/transaccion-completa-diferido/content/snippets/refund.ts
+++ b/src/app/transaccion-completa-diferido/content/snippets/refund.ts
@@ -3,7 +3,13 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 export const getStepOne = (token: string, amount: number) => {
   return `// Token: ${token}
 // Amount: ${amount}
-const refundRequest = await (new TransaccionCompleta.Transaction()).refund(token, amount);
+const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const refundRequest = await tx.refund(token, amount);
 `;
 };
 

--- a/src/app/transaccion-completa-diferido/content/snippets/status.ts
+++ b/src/app/transaccion-completa-diferido/content/snippets/status.ts
@@ -2,26 +2,30 @@ import { TBKFullTxStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (token_ws: string) => {
   return `// Token: ${token_ws}
-const statusResponse = await (new WebpayPlus.MallTransaction()).status(token);`;
+const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepTwo = (statusResponse: TBKFullTxStatusResponse) => {
-  return `
-  {
-    "amount": ${statusResponse.amount},
-    "status": "${statusResponse.status}",
-    "balance": ${statusResponse.balance},
-    "buy_order": "${statusResponse.buy_order}",
-    "session_id": "${statusResponse.session_id}",
-    "card_detail": {
-      "card_number": "${statusResponse.amount}"
-    },
-    "accounting_date": "${statusResponse.accounting_date}",
-    "transaction_date": "${statusResponse.transaction_date}",
-    "authorization_code": "${statusResponse.authorization_code}",
-    "payment_type_code": "${statusResponse.payment_type_code}",
-    "response_code": ${statusResponse.response_code},
-    "installments_number": ${statusResponse.installments_number}
-  }
-  `;
+  return `{
+  "amount": ${statusResponse.amount},
+  "status": "${statusResponse.status}",
+  "balance": ${statusResponse.balance},
+  "buy_order": "${statusResponse.buy_order}",
+  "session_id": "${statusResponse.session_id}",
+  "card_detail": {
+    "card_number": "${statusResponse.amount}"
+  },
+  "accounting_date": "${statusResponse.accounting_date}",
+  "transaction_date": "${statusResponse.transaction_date}",
+  "authorization_code": "${statusResponse.authorization_code}",
+  "payment_type_code": "${statusResponse.payment_type_code}",
+  "response_code": ${statusResponse.response_code},
+  "installments_number": ${statusResponse.installments_number}
+}`;
 };

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/commit.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/commit.ts
@@ -9,15 +9,15 @@ export const getStepOne = () => {
 
 const details = [
   new CommitDetail(
-    childCommerceCode1,
-    childBuyOrder1,
+    commerceCodeStore1,
+    buyOrderStore1,
     idQueryInstallments1,
     deferredPeriodIndex1,
     gracePeriod1
   ),
   new CommitDetail(
-    childCommerceCode2,
-    childBuyOrder2,
+    commerceCodeStore2,
+    buyOrderStore2,
     idQueryInstallments2,
     deferredPeriodIndex2,
     gracePeriod2

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/commit.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/commit.ts
@@ -1,9 +1,11 @@
 import { TBKMallCommitTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-const CommitDetail = require('transbank-sdk').CommitDetail; // CommonJS
-import { TransaccionCompleta, CommitDetail } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 const details = [
   new CommitDetail(
@@ -22,7 +24,7 @@ const details = [
   )
 ];
 
-const commitResponse = await (new TransaccionCompleta.MallTransaction()).commit(
+const commitResponse = await tx.commit(
   token,
   details
 );`;

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/create.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/create.ts
@@ -1,7 +1,31 @@
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-const TransactionDetail = require('transbank-sdk').TransactionDetail; // CommonJS
-import { TransaccionCompleta, TransactionDetail } from 'transbank-sdk'; // ES6 Modules
+  return `const {
+CommitDetail,
+Environment,
+InstallmentDetail,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+TransaccionCompleta,
+TransactionDetail
+} = require('transbank-sdk'); // ES5
+
+import { 
+CommitDetail,
+Environment,
+InstallmentDetail,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+TransaccionCompleta,
+TransactionDetail
+} from 'transbank-sdk'; // ES6
+
+const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
   
 const details = [
   new TransactionDetail(amount, childCommerceCode, childBuyOrder)
@@ -9,13 +33,13 @@ const details = [
 ];
   
 // Es necesario ejecutar dentro de una función async para utilizar await
-const createResponse = await (new TransaccionCompleta.MallTransaction()).create(
+const createResponse = await tx.create(
   buyOrder, 
   sessionId, 
-  cvv,
   cardNumber,
   cardExpirationDate,
-  details 
+  details,
+  cvv
 );`;
 };
 

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/create.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/create.ts
@@ -28,8 +28,8 @@ const tx = new TransaccionCompleta.MallTransaction(new Options(
 ));
   
 const details = [
-  new TransactionDetail(amount, childCommerceCode, childBuyOrder)
-  new TransactionDetail(amount2, childCommerceCode2, childBuyOrder2)
+  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1)
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2)
 ];
   
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/installments.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/installments.ts
@@ -8,8 +8,8 @@ export const getStepOne = () => {
 ));
 
 const installmentDetails = [
-  new InstallmentDetail(childCommerceCode1, childBuyOrder1, installmentsNumber)
-  new InstallmentDetail(childCommerceCode2, childBuyOrder2, installmentsNumber)
+  new InstallmentDetail(commerceCodeStore1, buyOrderStore1, installmentsNumber)
+  new InstallmentDetail(commerceCodeStore2, buyOrderStore2, installmentsNumber)
 ];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/installments.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/installments.ts
@@ -1,9 +1,11 @@
 import { TBKInstallmentsFullTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-const InstallmentDetail = require('transbank-sdk').InstallmentDetail; // CommonJS
-import { TransaccionCompleta, InstallmentDetail } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 const installmentDetails = [
   new InstallmentDetail(childCommerceCode1, childBuyOrder1, installmentsNumber)
@@ -11,7 +13,7 @@ const installmentDetails = [
 ];
 
 // Es necesario ejecutar dentro de una función async para utilizar await
-const installmentsResponse = await (new TransaccionCompleta.MallTransaction()).installments(
+const installmentsResponse = await tx.installments(
   token, 
   installmentDetails
 );`;

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/refund.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/refund.ts
@@ -3,8 +3,13 @@ import { TBKRefundMallTransactionResponse } from "@/types/transactions";
 export const getStepOne = (token: string, amount: string) => {
   return `// Token: ${token}
 // Amount: ${amount}
- 
-const refundRequest = await (new TransaccionCompleta.MallTransaction()).refund(
+const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const refundRequest = await tx.refund(
   token, buyOrder, commerceCode, amount
 );`;
 };

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/status.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/status.ts
@@ -2,7 +2,13 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (token: string) => {
   return `// Token: ${token}
-const statusResponse = await (new TransaccionCompleta.MallTransaction()).status(token);`;
+const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepTwo = (statusResponse: TBKMallTransactionStatusResponse) =>

--- a/src/app/transaccion-completa-mall/content/snippets/commit.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/commit.ts
@@ -9,15 +9,15 @@ export const getStepOne = () => {
 
 const details = [
   new CommitDetail(
-    childCommerceCode1,
-    childBuyOrder1,
+    commerceCodeStore1,
+    buyOrderStore1,
     idQueryInstallments1,
     deferredPeriodIndex1,
     gracePeriod1
   ),
   new CommitDetail(
-    childCommerceCode2,
-    childBuyOrder2,
+    commerceCodeStore2,
+    buyOrderStore2,
     idQueryInstallments2,
     deferredPeriodIndex2,
     gracePeriod2

--- a/src/app/transaccion-completa-mall/content/snippets/commit.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/commit.ts
@@ -1,9 +1,11 @@
 import { TBKMallCommitTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-const CommitDetail = require('transbank-sdk').CommitDetail; // CommonJS
-import { TransaccionCompleta, CommitDetail } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 const details = [
   new CommitDetail(
@@ -22,7 +24,7 @@ const details = [
   )
 ];
 
-const commitResponse = await (new TransaccionCompleta.MallTransaction()).commit(
+const commitResponse = await tx.commit(
   token,
   details
 );`;

--- a/src/app/transaccion-completa-mall/content/snippets/create.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/create.ts
@@ -1,7 +1,31 @@
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-const TransactionDetail = require('transbank-sdk').TransactionDetail; // CommonJS
-import { TransaccionCompleta, TransactionDetail } from 'transbank-sdk'; // ES6 Modules
+  return `const {
+CommitDetail,
+Environment,
+InstallmentDetail,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+TransaccionCompleta,
+TransactionDetail
+} = require('transbank-sdk'); // ES5
+
+import { 
+CommitDetail,
+Environment,
+InstallmentDetail,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+TransaccionCompleta, 
+TransactionDetail 
+} from 'transbank-sdk'; // ES6
+
+const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
   
 const details = [
   new TransactionDetail(amount, childCommerceCode, childBuyOrder)
@@ -9,13 +33,13 @@ const details = [
 ];
   
 // Es necesario ejecutar dentro de una función async para utilizar await
-const createResponse = await (new TransaccionCompleta.MallTransaction()).create(
+const createResponse = await tx.create(
   buyOrder, 
   sessionId, 
-  cvv,
   cardNumber,
   cardExpirationDate,
-  details 
+  details,
+  cvv
 );`;
 };
 

--- a/src/app/transaccion-completa-mall/content/snippets/create.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/create.ts
@@ -28,8 +28,8 @@ const tx = new TransaccionCompleta.MallTransaction(new Options(
 ));
   
 const details = [
-  new TransactionDetail(amount, childCommerceCode, childBuyOrder)
-  new TransactionDetail(amount2, childCommerceCode2, childBuyOrder2)
+  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1)
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2)
 ];
   
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall/content/snippets/installments.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/installments.ts
@@ -1,9 +1,11 @@
 import { TBKInstallmentsFullTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-const InstallmentDetail = require('transbank-sdk').InstallmentDetail; // CommonJS
-import { TransaccionCompleta, InstallmentDetail } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 const installmentDetails = [
   new InstallmentDetail(childCommerceCode1, childBuyOrder1, installmentsNumber)
@@ -11,7 +13,7 @@ const installmentDetails = [
 ];
 
 // Es necesario ejecutar dentro de una función async para utilizar await
-const installmentsResponse = await (new TransaccionCompleta.MallTransaction()).installments(
+const installmentsResponse = await tx.installments(
   token, 
   installmentDetails
 );`;

--- a/src/app/transaccion-completa-mall/content/snippets/installments.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/installments.ts
@@ -8,8 +8,8 @@ export const getStepOne = () => {
 ));
 
 const installmentDetails = [
-  new InstallmentDetail(childCommerceCode1, childBuyOrder1, installmentsNumber)
-  new InstallmentDetail(childCommerceCode2, childBuyOrder2, installmentsNumber)
+  new InstallmentDetail(commerceCodeStore1, buyOrderStore1, installmentsNumber)
+  new InstallmentDetail(commerceCodeStore2, buyOrderStore2, installmentsNumber)
 ];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall/content/snippets/refund.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/refund.ts
@@ -3,8 +3,14 @@ import { TBKRefundMallTransactionResponse } from "@/types/transactions";
 export const getStepOne = (token: string, amount: string) => {
   return `// Token: ${token}
 // Amount: ${amount}
- 
-const refundRequest = await (new TransaccionCompleta.MallTransaction()).refund(
+
+const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const refundRequest = await tx.refund(
   token, buyOrder, commerceCode, amount
 );`;
 };

--- a/src/app/transaccion-completa-mall/content/snippets/status.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/status.ts
@@ -2,7 +2,13 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (token: string) => {
   return `// Token: ${token}
-const statusResponse = await (new TransaccionCompleta.MallTransaction()).status(token);`;
+const tx = new TransaccionCompleta.MallTransaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepTwo = (statusResponse: TBKMallTransactionStatusResponse) =>

--- a/src/app/transaccion-completa/content/snippets/commit.ts
+++ b/src/app/transaccion-completa/content/snippets/commit.ts
@@ -1,10 +1,13 @@
 import { TBKFullTxCommitResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // CommonJS
-import { TransaccionCompleta } from 'transbank-sdk'; // ES6 Modules
+  return `const tx = new TransaccionCompleta.Transaction(new Options (
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
-const commitResponse = await (new TransaccionCompleta.Transaction()).commit(
+const commitResponse = await tx.commit(
   token,
   idQueryInstallments,(opcional)
   deferred_period_index, (opcional)

--- a/src/app/transaccion-completa/content/snippets/create.ts
+++ b/src/app/transaccion-completa/content/snippets/create.ts
@@ -1,9 +1,28 @@
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // ES5
-import { TransaccionCompleta } from 'transbank-sdk'; // ES6
+  return `const {
+Options,
+IntegrationCommerceCodes,
+IntegrationApiKeys,
+Environment,
+TransaccionCompleta
+} = require('transbank-sdk') // ES5
+
+import {
+Options,
+IntegrationCommerceCodes,
+IntegrationApiKeys,
+Environment,
+TransaccionCompleta 
+} from 'transbank-sdk'; // ES6
+
+const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 // Es necesario ejecutar dentro de una función async para utilizar await
-const createResponse = await (new TransaccionCompleta.Transaction()).create(
+const createResponse = await tx.create(
   buyOrder, 
   sessionId, 
   amount, 

--- a/src/app/transaccion-completa/content/snippets/installments.tsx
+++ b/src/app/transaccion-completa/content/snippets/installments.tsx
@@ -1,9 +1,12 @@
 import { InstallmentsFullTXResponse } from "@/types/transactions";
 export const getStepOne = () => {
-  return `const TransaccionCompleta = require('transbank-sdk').TransaccionCompleta; // ES5
-import { TransaccionCompleta } from 'transbank-sdk'; // ES6
+  return `const tx = new TranaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
-const installmentsResponse = await (new TransaccionCompleta.Transaction()).installments(
+const installmentsResponse = await tx.installments(
   token, 
   installments, 
 );`;

--- a/src/app/transaccion-completa/content/snippets/refund.ts
+++ b/src/app/transaccion-completa/content/snippets/refund.ts
@@ -3,7 +3,13 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 export const getStepOne = (token: string, amount: number) => {
   return `// Token: ${token}
 // Amount: ${amount}
-const refundRequest = await (new TransaccionCompleta.Transaction()).refund(token, amount);
+const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const refundRequest = await tx.refund(token, amount);
 `;
 };
 

--- a/src/app/transaccion-completa/content/snippets/status.ts
+++ b/src/app/transaccion-completa/content/snippets/status.ts
@@ -2,26 +2,30 @@ import { TBKFullTxStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (token_ws: string) => {
   return `// Token: ${token_ws}
-const statusResponse = await (new WebpayPlus.MallTransaction()).status(token);`;
+const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepTwo = (statusResponse: TBKFullTxStatusResponse) => {
-  return `
-  {
-    "amount": ${statusResponse.amount},
-    "status": "${statusResponse.status}",
-    "balance": ${statusResponse.balance},
-    "buy_order": "${statusResponse.buy_order}",
-    "session_id": "${statusResponse.session_id}",
-    "card_detail": {
-      "card_number": "${statusResponse.amount}"
-    },
-    "accounting_date": "${statusResponse.accounting_date}",
-    "transaction_date": "${statusResponse.transaction_date}",
-    "authorization_code": "${statusResponse.authorization_code}",
-    "payment_type_code": "${statusResponse.payment_type_code}",
-    "response_code": ${statusResponse.response_code},
-    "installments_number": ${statusResponse.installments_number}
-  }
-  `;
+  return `{
+  "amount": ${statusResponse.amount},
+  "status": "${statusResponse.status}",
+  "balance": ${statusResponse.balance},
+  "buy_order": "${statusResponse.buy_order}",
+  "session_id": "${statusResponse.session_id}",
+  "card_detail": {
+    "card_number": "${statusResponse.amount}"
+  },
+  "accounting_date": "${statusResponse.accounting_date}",
+  "transaction_date": "${statusResponse.transaction_date}",
+  "authorization_code": "${statusResponse.authorization_code}",
+  "payment_type_code": "${statusResponse.payment_type_code}",
+  "response_code": ${statusResponse.response_code},
+  "installments_number": ${statusResponse.installments_number}
+}`;
 };

--- a/src/app/webpay-mall-diferido/content/snippets/capture.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/capture.ts
@@ -2,7 +2,13 @@ import { TBKCaptureTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = (token: string) => {
   return `//token: ${token}
-  const captureResponse = await (new WebpayPlus.Transaction()).capture(
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const captureResponse = await tx.capture(
   token,
   buyOrder,
   authorizationCode,

--- a/src/app/webpay-mall-diferido/content/snippets/commit.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/commit.ts
@@ -7,9 +7,15 @@ export const getStepOne = (token: string) => {
 };
 
 export const getStepTwo = () => {
-  return `
-const token = request.body.token_ws;
-const commitResponse = await (new WebpayPlus.MallTransaction()).commit(token);`;
+  return `const token = request.body.token_ws;
+
+const tx = new WebpayPlus.MallTransaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const commitResponse = await tx.commit(token);`;
 };
 
 export const getStepThree = (
@@ -26,37 +32,35 @@ export const getStepThree = (
   } = commitResponse;
 
   return `{
-    "vci": "${vci}",
-    "buy_order": "${buy_order}",
-    "session_id": "${session_id}",
-    "card_detail": {
-      "card_number": "${card_detail.card_number}",
+  "vci": "${vci}",
+  "buy_order": "${buy_order}",
+  "session_id": "${session_id}",
+  "card_detail": {
+    "card_number": "${card_detail.card_number}",
+  },
+  "accounting_date": "${accounting_date}",
+  "transaction_date": "${transaction_date}",
+  "details": [
+    {
+      "amount": ${details[0].amount},
+      "status": "${details[0].status}",
+      "authorization_code": "${details[0].authorization_code}",
+      "payment_type_code": "${details[0].payment_type_code}",
+      "response_code": ${details[0].response_code},
+      "installments_number": ${details[0].installments_number},
+      "commerce_code": "${details[0].commerce_code}",
+      "buy_order": "${details[0].buy_order}"
     },
-    "accounting_date": "${accounting_date}",
-    "transaction_date": "${transaction_date}",
-    "details": [
-      {
-        "amount": ${details[0].amount},
-        "status": "${details[0].status}",
-        "authorization_code": "${details[0].authorization_code}",
-        "payment_type_code": "${details[0].payment_type_code}",
-        "response_code": ${details[0].response_code},
-        "installments_number": ${details[0].installments_number},
-        "commerce_code": "${details[0].commerce_code}",
-        "buy_order": "${details[0].buy_order}"
-      },
-      {
-        "amount": ${details[1].amount},
-        "status": "${details[1].status}",
-        "authorization_code": "${details[1].authorization_code}",
-        "payment_type_code": "${details[1].payment_type_code}",
-        "response_code": ${details[1].response_code},
-        "installments_number": ${details[1].installments_number},
-        "commerce_code": "${details[1].commerce_code}",
-        "buy_order": "${details[1].buy_order}"
-      }
-    ],
-  }
-  
- `;
+    {
+      "amount": ${details[1].amount},
+      "status": "${details[1].status}",
+      "authorization_code": "${details[1].authorization_code}",
+      "payment_type_code": "${details[1].payment_type_code}",
+      "response_code": ${details[1].response_code},
+      "installments_number": ${details[1].installments_number},
+      "commerce_code": "${details[1].commerce_code}",
+      "buy_order": "${details[1].buy_order}"
+    }
+  ],
+}`;
 };

--- a/src/app/webpay-mall-diferido/content/snippets/create.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/create.ts
@@ -1,20 +1,39 @@
 export const getStepOne = () => {
-  return `const WebpayPlus = require('transbank-sdk').WebpayPlus; // ES5
-  const TransactionDetail = require("transbank-sdk").TransactionDetail;
-  
-  import { WebpayPlus, TransactionDetail } from 'transbank-sdk'; // ES6
+  return `const {
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+TransactionDetail,
+WebpayPlus
+} = require('transbank-sdk') // ES5
+ 
+import { 
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+TransactionDetail,
+WebpayPlus 
+} from 'transbank-sdk'; // ES6
 
-  let details = [
-    new TransactionDetail(135, "597055555536", "O-23101"),
-    new TransactionDetail(148, "597055555536", "O-10821"),
-  ]
+const tx = new WebpayPlus.MallTransaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+let details = [
+  new TransactionDetail(135, "597055555536", "O-23101"),
+  new TransactionDetail(148, "597055555536", "O-10821"),
+]
   
-  const createResponse = await (new WebpayPlus.MallTransaction()).create(
-    buyOrder, 
-    sessionId, 
-    returnUrl,
-    details
-  );`;
+const createResponse = await tx.create(
+  buyOrder, 
+  sessionId, 
+  returnUrl,
+  details
+);`;
 };
 
 export const getStepTwo = (token: string) => {

--- a/src/app/webpay-mall-diferido/content/snippets/refund.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/refund.ts
@@ -3,7 +3,13 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 export const getStepOne = (amount: string) => {
   return `// Token: 01ab8fb16e5dee67fcc392b97d679a01d29b77b4cd8b9ee6ade278203feee1b4
 // Amount: ${amount}
-const refundRequest = await(new WebpayPlus.MallTransaction()).refund(
+const tx = new WebpayPlus.MallTransaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const refundRequest = await tx.refund(
   token,
   buyOrder,
   commerceCode,

--- a/src/app/webpay-mall-diferido/content/snippets/refund.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/refund.ts
@@ -1,7 +1,7 @@
 import { TBKRefundTransactionResponse } from "@/types/transactions";
 
-export const getStepOne = (amount: string) => {
-  return `// Token: 01ab8fb16e5dee67fcc392b97d679a01d29b77b4cd8b9ee6ade278203feee1b4
+export const getStepOne = (amount: string, token_ws: string) => {
+  return `// Token: ${token_ws}
 // Amount: ${amount}
 const tx = new WebpayPlus.MallTransaction(new Options(
   IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,

--- a/src/app/webpay-mall-diferido/content/snippets/status.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/status.ts
@@ -2,7 +2,13 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (token_ws: string) => {
   return `// Token: ${token_ws}
-const statusResponse = await (new WebpayPlus.MallTransaction()).status(token);`;
+const tx = new WebpayPlus.MallTransaction(new Options(
+  IntegrationCommercecodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepTwo = (
@@ -10,34 +16,32 @@ export const getStepTwo = (
 ) => {
   const { buy_order, session_id, accounting_date, transaction_date, details } =
     commitResponse;
-  return `
-  {
-    details: [
-      {
-        amount: "${details[0].amount}",
-        status: "${details[0].status}",
-        authorization_code: "${details[0].authorization_code}",
-        payment_type_code: "${details[0].payment_type_code}",
-        response_code: ${details[0].response_code},
-        installments_number: ${details[0].installments_number},
-        commerce_code: "${details[0].commerce_code}",
-        buy_order: "${details[0].buy_order}"
-      },
-      {
-        amount: "${details[1].amount}",
-        status: "${details[1].status}",
-        authorization_code: "${details[1].authorization_code}",
-        payment_type_code: "${details[1].payment_type_code}",
-        response_code: ${details[1].response_code},
-        installments_number: ${details[1].installments_number},
-        commerce_code: "${details[1].commerce_code}",
-        buy_order: "${details[1].buy_order}"
-      }
-    ],
-    buy_order: "${buy_order}",
-    session_id: "${session_id}",
-    accounting_date: "${accounting_date}",
-    transaction_date: "${transaction_date}"
-  }
-  `;
+  return `{
+  details: [
+    {
+      amount: "${details[0].amount}",
+      status: "${details[0].status}",
+      authorization_code: "${details[0].authorization_code}",
+      payment_type_code: "${details[0].payment_type_code}",
+      response_code: ${details[0].response_code},
+      installments_number: ${details[0].installments_number},
+      commerce_code: "${details[0].commerce_code}",
+      buy_order: "${details[0].buy_order}"
+    },
+    {
+      amount: "${details[1].amount}",
+      status: "${details[1].status}",
+      authorization_code: "${details[1].authorization_code}",
+      payment_type_code: "${details[1].payment_type_code}",
+      response_code: ${details[1].response_code},
+      installments_number: ${details[1].installments_number},
+      commerce_code: "${details[1].commerce_code}",
+      buy_order: "${details[1].buy_order}"
+    }
+  ],
+  buy_order: "${buy_order}",
+  session_id: "${session_id}",
+  accounting_date: "${accounting_date}",
+  transaction_date: "${transaction_date}"
+}`;
 };

--- a/src/app/webpay-mall-diferido/content/steps/commit.tsx
+++ b/src/app/webpay-mall-diferido/content/steps/commit.tsx
@@ -1,6 +1,6 @@
 import { StepProps } from "@/components/step/Step";
 import { TBKMallCommitTransactionResponse } from "@/types/transactions";
-import * as commitSnippets from "@/app/webpay-mall/content/snippets/commit";
+import * as commitSnippets from "@/app/webpay-mall-diferido/content/snippets/commit";
 import { Text } from "@/components/text/Text";
 import { OkCommitMessage } from "@/components/messages/OkCommitMessage";
 import { OperationsCommitDeferredMessage } from "@/components/messages/OperationsCommitDeferredMessage";

--- a/src/app/webpay-mall-diferido/content/steps/refund.tsx
+++ b/src/app/webpay-mall-diferido/content/steps/refund.tsx
@@ -5,7 +5,8 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 
 export const getRefundTRXSteps = (
   refundResult: TBKRefundTransactionResponse,
-  amount: string
+  amount: string,
+  token_ws: string
 ): StepProps[] => {
   return [
     {
@@ -46,7 +47,7 @@ export const getRefundTRXSteps = (
           </div>
         </div>
       ),
-      code: refundSnippets.getStepOne(amount),
+      code: refundSnippets.getStepOne(amount, token_ws),
     },
     {
       stepTitle: "Paso 2: Respuesta",

--- a/src/app/webpay-mall-diferido/refund/page.tsx
+++ b/src/app/webpay-mall-diferido/refund/page.tsx
@@ -57,7 +57,7 @@ export default async function RefundTransaction({
                 están soportadas.`}
       actualBread={actualBread}
       activeRoute="/webpay-mall-diferido/refund"
-      steps={getRefundTRXSteps(refundResult, amount as string, token_ws as string)}
+      steps={getRefundTRXSteps(refundResult, amount as string, token_ws)}
       additionalContent={
         <StatusButton className="mt-6" token={token_ws as string} />
       }

--- a/src/app/webpay-mall-diferido/refund/page.tsx
+++ b/src/app/webpay-mall-diferido/refund/page.tsx
@@ -57,7 +57,7 @@ export default async function RefundTransaction({
                 están soportadas.`}
       actualBread={actualBread}
       activeRoute="/webpay-mall-diferido/refund"
-      steps={getRefundTRXSteps(refundResult, amount as string)}
+      steps={getRefundTRXSteps(refundResult, amount as string, token_ws as string)}
       additionalContent={
         <StatusButton className="mt-6" token={token_ws as string} />
       }

--- a/src/app/webpay-mall/content/snippets/commit.ts
+++ b/src/app/webpay-mall/content/snippets/commit.ts
@@ -7,9 +7,13 @@ export const getStepOne = (token: string) => {
 };
 
 export const getStepTwo = () => {
-  return `
-const token = request.body.token_ws;
-const commitResponse = await (new WebpayPlus.MallTransaction()).commit(token);`;
+  return `const token = request.body.token_ws;
+const tx = new WebpayPlus.MallTransaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const commitResponse = await tx.commit(token);`;
 };
 
 export const getStepThree = (

--- a/src/app/webpay-mall/content/snippets/create.ts
+++ b/src/app/webpay-mall/content/snippets/create.ts
@@ -1,20 +1,26 @@
 export const getStepOne = () => {
   return `const WebpayPlus = require('transbank-sdk').WebpayPlus; // ES5
-  const TransactionDetail = require("transbank-sdk").TransactionDetail;
+const TransactionDetail = require("transbank-sdk").TransactionDetail;
   
-  import { WebpayPlus, TransactionDetail } from 'transbank-sdk'; // ES6
+import { WebpayPlus, TransactionDetail } from 'transbank-sdk'; // ES6
 
-  let details = [
-    new TransactionDetail(135, "597055555536", "O-23101"),
-    new TransactionDetail(148, "597055555536", "O-10821"),
-  ]
+const tx = new WebpayPlus.MallTransaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+let details = [
+  new TransactionDetail(135, "597055555536", "O-23101"),
+  new TransactionDetail(148, "597055555536", "O-10821"),
+]
   
-  const createResponse = await (new WebpayPlus.MallTransaction()).create(
-    buyOrder, 
-    sessionId, 
-    returnUrl,
-    details
-  );`;
+const createResponse = await tx.create(
+  buyOrder, 
+  sessionId, 
+  returnUrl,
+  details
+);`;
 };
 
 export const getStepTwo = (token: string) => {

--- a/src/app/webpay-mall/content/snippets/create.ts
+++ b/src/app/webpay-mall/content/snippets/create.ts
@@ -1,8 +1,21 @@
 export const getStepOne = () => {
-  return `const WebpayPlus = require('transbank-sdk').WebpayPlus; // ES5
-const TransactionDetail = require("transbank-sdk").TransactionDetail;
-  
-import { WebpayPlus, TransactionDetail } from 'transbank-sdk'; // ES6
+  return `const {
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+TransactionDetail,
+WebpayPlus
+} = require('transbank-sdk'); // ES5
+
+import { 
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+TransactionDetail,
+WebpayPlus 
+} from 'transbank-sdk'; // ES6
 
 const tx = new WebpayPlus.MallTransaction(new Options(
   IntegrationCommerceCodes.WEBPAY_PLUS_MALL,

--- a/src/app/webpay-mall/content/snippets/refund.ts
+++ b/src/app/webpay-mall/content/snippets/refund.ts
@@ -3,7 +3,12 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 export const getStepOne = (amount: string) => {
   return `// Token: 01ab8fb16e5dee67fcc392b97d679a01d29b77b4cd8b9ee6ade278203feee1b4
 // Amount: ${amount}
-const refundRequest = await (new WebpayPlus.MallTransaction()).refund(
+const tx = new WebpayPlus.MallTransaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const refundRequest = await tx.refund(
   token,
   buyOrder,
   commerceCode,

--- a/src/app/webpay-mall/content/snippets/refund.ts
+++ b/src/app/webpay-mall/content/snippets/refund.ts
@@ -1,7 +1,7 @@
 import { TBKRefundTransactionResponse } from "@/types/transactions";
 
-export const getStepOne = (amount: string) => {
-  return `// Token: 01ab8fb16e5dee67fcc392b97d679a01d29b77b4cd8b9ee6ade278203feee1b4
+export const getStepOne = (amount: string, token_ws: string) => {
+  return `// Token: ${token_ws}
 // Amount: ${amount}
 const tx = new WebpayPlus.MallTransaction(new Options(
   IntegrationCommerceCodes.WEBPAY_PLUS_MALL,

--- a/src/app/webpay-mall/content/snippets/status.ts
+++ b/src/app/webpay-mall/content/snippets/status.ts
@@ -2,7 +2,12 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (token_ws: string) => {
   return `// Token: ${token_ws}
-const statusResponse = await (new WebpayPlus.MallTransaction()).status(token);`;
+const tx = new WebpayPlus.MallTransaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepTwo = (
@@ -10,34 +15,32 @@ export const getStepTwo = (
 ) => {
   const { buy_order, session_id, accounting_date, transaction_date, details } =
     commitResponse;
-  return `
-  {
-    details: [
-      {
-        amount: "${details[0].amount}",
-        status: "${details[0].status}",
-        authorization_code: "${details[0].authorization_code}",
-        payment_type_code: "${details[0].payment_type_code}",
-        response_code: ${details[0].response_code},
-        installments_number: ${details[0].installments_number},
-        commerce_code: "${details[0].commerce_code}",
-        buy_order: "${details[0].buy_order}"
-      },
-      {
-        amount: "${details[1].amount}",
-        status: "${details[1].status}",
-        authorization_code: "${details[1].authorization_code}",
-        payment_type_code: "${details[1].payment_type_code}",
-        response_code: ${details[1].response_code},
-        installments_number: ${details[1].installments_number},
-        commerce_code: "${details[1].commerce_code}",
-        buy_order: "${details[1].buy_order}"
-      }
-    ],
-    buy_order: "${buy_order}",
-    session_id: "${session_id}",
-    accounting_date: "${accounting_date}",
-    transaction_date: "${transaction_date}"
-  }
-  `;
+  return `{
+  details: [
+    {
+      amount: "${details[0].amount}",
+      status: "${details[0].status}",
+      authorization_code: "${details[0].authorization_code}",
+      payment_type_code: "${details[0].payment_type_code}",
+      response_code: ${details[0].response_code},
+      installments_number: ${details[0].installments_number},
+      commerce_code: "${details[0].commerce_code}",
+      buy_order: "${details[0].buy_order}"
+    },
+    {
+      amount: "${details[1].amount}",
+      status: "${details[1].status}",
+      authorization_code: "${details[1].authorization_code}",
+      payment_type_code: "${details[1].payment_type_code}",
+      response_code: ${details[1].response_code},
+      installments_number: ${details[1].installments_number},
+      commerce_code: "${details[1].commerce_code}",
+      buy_order: "${details[1].buy_order}"
+    }
+  ],
+  buy_order: "${buy_order}",
+  session_id: "${session_id}",
+  accounting_date: "${accounting_date}",
+  transaction_date: "${transaction_date}"
+}`;
 };

--- a/src/app/webpay-mall/content/steps/refund.tsx
+++ b/src/app/webpay-mall/content/steps/refund.tsx
@@ -5,7 +5,8 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 
 export const getRefundTRXSteps = (
   refundResult: TBKRefundTransactionResponse,
-  amount: string
+  amount: string,
+  token_ws: string
 ): StepProps[] => {
   return [
     {
@@ -46,7 +47,7 @@ export const getRefundTRXSteps = (
           </div>
         </div>
       ),
-      code: refundSnippets.getStepOne(amount),
+      code: refundSnippets.getStepOne(amount, token_ws),
     },
     {
       stepTitle: "Paso 2: Respuesta",

--- a/src/app/webpay-mall/refund/page.tsx
+++ b/src/app/webpay-mall/refund/page.tsx
@@ -59,7 +59,7 @@ export default async function RefundTransaction({
                 están soportadas.`}
       actualBread={actualBread}
       activeRoute="/webpay-mall/refund"
-      steps={getRefundTRXSteps(refundResult, amount as string, token_ws as string)}
+      steps={getRefundTRXSteps(refundResult, amount as string, token_ws)}
       additionalContent={
         <StatusButton className="mt-6" token={token_ws as string} />
       }

--- a/src/app/webpay-mall/refund/page.tsx
+++ b/src/app/webpay-mall/refund/page.tsx
@@ -59,7 +59,7 @@ export default async function RefundTransaction({
                 están soportadas.`}
       actualBread={actualBread}
       activeRoute="/webpay-mall/refund"
-      steps={getRefundTRXSteps(refundResult, amount as string)}
+      steps={getRefundTRXSteps(refundResult, amount as string, token_ws as string)}
       additionalContent={
         <StatusButton className="mt-6" token={token_ws as string} />
       }

--- a/src/app/webpay-plus-deferred/content/snippets/capture.ts
+++ b/src/app/webpay-plus-deferred/content/snippets/capture.ts
@@ -2,7 +2,13 @@ import { TBKCaptureTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = (token: string) => {
   return `//token: ${token}
-  const captureResponse = await (new WebpayPlus.Transaction()).capture(
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const captureResponse = await tx.capture(
   token,
   buyOrder,
   authorizationCode,

--- a/src/app/webpay-plus-deferred/content/snippets/commit.ts
+++ b/src/app/webpay-plus-deferred/content/snippets/commit.ts
@@ -7,9 +7,13 @@ export const getStepOne = (token: string) => {
 };
 
 export const getStepTwo = () => {
-  return `
-const token = request.body.token_ws;
-const commitResponse = await (new WebpayPlus.Transaction()).commit(token);`;
+  return `const token = request.body.token_ws;
+const tx = new WebpayPlus.Transaction(new Options (
+  IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const commitResponse = await tx.commit(token);`;
 };
 
 export const getStepThree = (commitResponse: TBKCommitTransactionResponse) => {

--- a/src/app/webpay-plus-deferred/content/snippets/create.ts
+++ b/src/app/webpay-plus-deferred/content/snippets/create.ts
@@ -1,9 +1,28 @@
 export const getStepOne = () => {
-  return `const WebpayPlus = require('transbank-sdk').WebpayPlus; // ES5
-import { WebpayPlus } from 'transbank-sdk'; // ES6
+  return `const {
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+WebpayPlus
+} = require('transbank-sdk') // ES5
+ 
+import { 
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+WebpayPlus 
+} from 'transbank-sdk'; // ES6
+
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
 
 // Es necesario ejecutar dentro de una función async para utilizar await
-const createResponse = await (new WebpayPlus.Transaction()).create(
+const createResponse = await tx.create(
   buyOrder, 
   sessionId, 
   amount, 

--- a/src/app/webpay-plus-deferred/content/snippets/refund.ts
+++ b/src/app/webpay-plus-deferred/content/snippets/refund.ts
@@ -1,7 +1,7 @@
 import { TBKRefundTransactionResponse } from "@/types/transactions";
 
-export const getStepOne = (amount: string) => {
-  return `// Token: 01ab8fb16e5dee67fcc392b97d679a01d29b77b4cd8b9ee6ade278203feee1b4
+export const getStepOne = (amount: string, token_ws: string) => {
+  return `// Token: ${token_ws}
 // Amount: ${amount}
 const tx = new WebpayPlus.Transaction(new Options(
   IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,

--- a/src/app/webpay-plus-deferred/content/snippets/refund.ts
+++ b/src/app/webpay-plus-deferred/content/snippets/refund.ts
@@ -3,7 +3,12 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 export const getStepOne = (amount: string) => {
   return `// Token: 01ab8fb16e5dee67fcc392b97d679a01d29b77b4cd8b9ee6ade278203feee1b4
 // Amount: ${amount}
-const refundRequest = await (new WebpayPlus.Transaction()).refund(token, amount);`;
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const refundRequest = await tx.refund(token, amount);`;
 };
 
 export const getStepTwo = (refundResult: TBKRefundTransactionResponse) => {

--- a/src/app/webpay-plus-deferred/content/snippets/status.ts
+++ b/src/app/webpay-plus-deferred/content/snippets/status.ts
@@ -2,7 +2,12 @@ import { TBKTransactionStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (token_ws: string) => {
   return `// Token: ${token_ws}
-const statusResponse = await (new WebpayPlus.Transaction()).status(token);`;
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepTwo = (commitResponse: TBKTransactionStatusResponse) => {
@@ -23,5 +28,5 @@ export const getStepTwo = (commitResponse: TBKTransactionStatusResponse) => {
   "accounting_date": "${accounting_date}",
   "transaction_date": "${transaction_date}",
   "installments_number": "${installments_number}"
-  }`;
+}`;
 };

--- a/src/app/webpay-plus-deferred/content/steps/commit.tsx
+++ b/src/app/webpay-plus-deferred/content/steps/commit.tsx
@@ -3,7 +3,7 @@ import {
   TBKCommitTransactionResponse,
   TBKTransactionStatus,
 } from "@/types/transactions";
-import * as commitSnippets from "@/app/webpay-plus/content/snippets/commit";
+import * as commitSnippets from "@/app/webpay-plus-deferred/content/snippets/commit";
 import { Text } from "@/components/text/Text";
 import { OkCommitMessage } from "@/components/messages/OkCommitMessage";
 import { OperationsCommitDeferredMessage } from "@/components/messages/OperationsCommitDeferredMessage";

--- a/src/app/webpay-plus-deferred/content/steps/create.tsx
+++ b/src/app/webpay-plus-deferred/content/steps/create.tsx
@@ -1,6 +1,6 @@
 import { StepProps } from "@/components/step/Step";
 import { StartTransactionData } from "@/types/transactions";
-import * as createSnippets from "@/app/webpay-plus/content/snippets/create";
+import * as createSnippets from "@/app/webpay-plus-deferred/content/snippets/create";
 import { Table } from "@/components/table/Table";
 import {
   getColumnDefinition,

--- a/src/app/webpay-plus-deferred/content/steps/refund.tsx
+++ b/src/app/webpay-plus-deferred/content/steps/refund.tsx
@@ -5,7 +5,8 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 
 export const getRefundTRXSteps = (
   refundResult: TBKRefundTransactionResponse,
-  amount: string
+  amount: string,
+  token_ws: string
 ): StepProps[] => {
   return [
     {
@@ -37,7 +38,7 @@ export const getRefundTRXSteps = (
           </div>
         </div>
       ),
-      code: refundSnippets.getStepOne(amount),
+      code: refundSnippets.getStepOne(amount,token_ws),
     },
     {
       stepTitle: "Paso 2: Respuesta",

--- a/src/app/webpay-plus-deferred/content/steps/refund.tsx
+++ b/src/app/webpay-plus-deferred/content/steps/refund.tsx
@@ -1,5 +1,5 @@
 import { StepProps } from "@/components/step/Step";
-import * as refundSnippets from "@/app/webpay-plus/content/snippets/refund";
+import * as refundSnippets from "@/app/webpay-plus-deferred/content/snippets/refund";
 import { Text } from "@/components/text/Text";
 import { TBKRefundTransactionResponse } from "@/types/transactions";
 

--- a/src/app/webpay-plus-deferred/content/steps/status.tsx
+++ b/src/app/webpay-plus-deferred/content/steps/status.tsx
@@ -1,6 +1,6 @@
 import { StepProps } from "@/components/step/Step";
 import { TBKTransactionStatusResponse } from "@/types/transactions";
-import * as statusSnippets from "@/app/webpay-plus/content/snippets/status";
+import * as statusSnippets from "@/app/webpay-plus-deferred/content/snippets/status";
 import { Text } from "@/components/text/Text";
 
 export const getStatusTRXSteps = (

--- a/src/app/webpay-plus-deferred/page.tsx
+++ b/src/app/webpay-plus-deferred/page.tsx
@@ -8,7 +8,7 @@ import {
 import { Button, ButtonTypes } from "@/components/button/Button";
 import { Card } from "@/components/card/Card";
 import { Layout } from "@/components/layout/Layout";
-import { getCreateTRXSteps } from "@/app/webpay-plus/content/steps/create";
+import { getCreateTRXSteps } from "@/app/webpay-plus-deferred/content/steps/create";
 import Head from "next/head";
 import { createTransaction } from "../lib/webpay-plus-deferred/data";
 import { NavigationItem } from "@/components/layout/Navigation";

--- a/src/app/webpay-plus-deferred/refund/page.tsx
+++ b/src/app/webpay-plus-deferred/refund/page.tsx
@@ -1,7 +1,7 @@
 import "./page.css";
 import { Route } from "@/types/menu";
 import { Layout } from "@/components/layout/Layout";
-import { getRefundTRXSteps } from "@/app/webpay-plus/content/steps/refund";
+import { getRefundTRXSteps } from "@/app/webpay-plus-deferred/content/steps/refund";
 import { NextPageProps } from "@/types/general";
 import { refundTransaction } from "@/app/lib/webpay-plus-deferred/data";
 import { CustomError } from "@/components/customError/CustomError";

--- a/src/app/webpay-plus-deferred/refund/page.tsx
+++ b/src/app/webpay-plus-deferred/refund/page.tsx
@@ -56,7 +56,7 @@ export default async function RefundTransaction({
                 están soportadas.`}
       actualBread={actualBread}
       activeRoute="/webpay-plus-deferred/refund"
-      steps={getRefundTRXSteps(refundResult, amount as string, token_ws as string)}
+      steps={getRefundTRXSteps(refundResult, amount as string, token_ws)}
       additionalContent={
         <StatusButton className="mt-6" token={token_ws as string} />
       }

--- a/src/app/webpay-plus-deferred/refund/page.tsx
+++ b/src/app/webpay-plus-deferred/refund/page.tsx
@@ -56,7 +56,7 @@ export default async function RefundTransaction({
                 están soportadas.`}
       actualBread={actualBread}
       activeRoute="/webpay-plus-deferred/refund"
-      steps={getRefundTRXSteps(refundResult, amount as string)}
+      steps={getRefundTRXSteps(refundResult, amount as string, token_ws as string)}
       additionalContent={
         <StatusButton className="mt-6" token={token_ws as string} />
       }

--- a/src/app/webpay-plus-deferred/status/page.tsx
+++ b/src/app/webpay-plus-deferred/status/page.tsx
@@ -1,7 +1,7 @@
 import { Route } from "@/types/menu";
 import { Layout } from "@/components/layout/Layout";
 import Head from "next/head";
-import { getStatusTRXSteps } from "@/app/webpay-plus/content/steps/status";
+import { getStatusTRXSteps } from "@/app/webpay-plus-deferred/content/steps/status";
 import { NextPageProps } from "@/types/general";
 import { getStatusTransaction } from "@/app/lib/webpay-plus-deferred/data";
 import { CustomError } from "@/components/customError/CustomError";

--- a/src/app/webpay-plus/content/snippets/commit.ts
+++ b/src/app/webpay-plus/content/snippets/commit.ts
@@ -7,9 +7,13 @@ export const getStepOne = (token: string) => {
 };
 
 export const getStepTwo = () => {
-  return `
-const token = request.body.token_ws;
-const commitResponse = await (new WebpayPlus.Transaction()).commit(token);`;
+  return `const token = request.body.token_ws;
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const commitResponse = await tx.commit(token);`;
 };
 
 export const getStepThree = (commitResponse: TBKCommitTransactionResponse) => {

--- a/src/app/webpay-plus/content/snippets/create.ts
+++ b/src/app/webpay-plus/content/snippets/create.ts
@@ -1,6 +1,19 @@
 export const getStepOne = () => {
-  return `const WebpayPlus = require('transbank-sdk').WebpayPlus; // ES5
-import { WebpayPlus } from 'transbank-sdk'; // ES6
+  return `const {
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+WebpayPlus
+} = require('transbank-sdk') // ES5
+
+import { 
+Environment,
+IntegrationApiKeys,
+IntegrationCommerceCodes,
+Options,
+WebpayPlus 
+} from 'transbank-sdk'; // ES6
 
 const tx = new WebpayPlus.Transaction(new Options(
   IntegrationCommerceCodes.WEBPAY_PLUS,

--- a/src/app/webpay-plus/content/snippets/create.ts
+++ b/src/app/webpay-plus/content/snippets/create.ts
@@ -2,8 +2,14 @@ export const getStepOne = () => {
   return `const WebpayPlus = require('transbank-sdk').WebpayPlus; // ES5
 import { WebpayPlus } from 'transbank-sdk'; // ES6
 
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
 // Es necesario ejecutar dentro de una función async para utilizar await
-const createResponse = await (new WebpayPlus.Transaction()).create(
+const createResponse = await tx.create(
   buyOrder, 
   sessionId, 
   amount, 

--- a/src/app/webpay-plus/content/snippets/refund.ts
+++ b/src/app/webpay-plus/content/snippets/refund.ts
@@ -3,7 +3,12 @@ import { TBKRefundTransactionResponse } from "@/types/transactions";
 export const getStepOne = (amount: string) => {
   return `// Token: 01ab8fb16e5dee67fcc392b97d679a01d29b77b4cd8b9ee6ade278203feee1b4
 // Amount: ${amount}
-const refundRequest = await (new WebpayPlus.Transaction()).refund(token, amount);`;
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const refundRequest = await tx.refund(token, amount);`;
 };
 
 export const getStepTwo = (refundResult: TBKRefundTransactionResponse) => {

--- a/src/app/webpay-plus/content/snippets/refund.ts
+++ b/src/app/webpay-plus/content/snippets/refund.ts
@@ -1,7 +1,7 @@
 import { TBKRefundTransactionResponse } from "@/types/transactions";
 
-export const getStepOne = (amount: string) => {
-  return `// Token: 01ab8fb16e5dee67fcc392b97d679a01d29b77b4cd8b9ee6ade278203feee1b4
+export const getStepOne = (amount: string, token_ws: string) => {
+  return `// Token: ${token_ws}
 // Amount: ${amount}
 const tx = new WebpayPlus.Transaction(new Options(
   IntegrationCommerceCodes.WEBPAY_PLUS,

--- a/src/app/webpay-plus/content/snippets/status.ts
+++ b/src/app/webpay-plus/content/snippets/status.ts
@@ -2,7 +2,12 @@ import { TBKTransactionStatusResponse } from "@/types/transactions";
 
 export const getStepOne = (token_ws: string) => {
   return `// Token: ${token_ws}
-const statusResponse = await (new WebpayPlus.Transaction()).status(token);`;
+const tx = new WebpayPlus.Transaction(new Options(
+  IntegrationCommerceCodes.WEBPAY_PLUS,
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+const statusResponse = await tx.status(token);`;
 };
 
 export const getStepTwo = (commitResponse: TBKTransactionStatusResponse) => {

--- a/src/app/webpay-plus/content/steps/refund.tsx
+++ b/src/app/webpay-plus/content/steps/refund.tsx
@@ -6,7 +6,8 @@ import Link from "next/link";
 
 export const getRefundTRXSteps = (
   refundResult: TBKRefundTransactionResponse,
-  amount: string
+  amount: string,
+  token_ws: string
 ): StepProps[] => {
   return [
     {
@@ -45,7 +46,7 @@ export const getRefundTRXSteps = (
           </div>
         </div>
       ),
-      code: refundSnippets.getStepOne(amount),
+      code: refundSnippets.getStepOne(amount, token_ws),
     },
     {
       stepTitle: "Paso 2: Respuesta",

--- a/src/app/webpay-plus/refund/page.tsx
+++ b/src/app/webpay-plus/refund/page.tsx
@@ -56,7 +56,7 @@ export default async function RefundTransaction({
                 están soportadas.`}
       actualBread={actualBread}
       activeRoute="/webpay-plus/refund"
-      steps={getRefundTRXSteps(refundResult, amount as string, token_ws as string)}
+      steps={getRefundTRXSteps(refundResult, amount as string, token_ws)}
       additionalContent={<StatusButton className="mt-6" token={token_ws} />}
     />
   );

--- a/src/app/webpay-plus/refund/page.tsx
+++ b/src/app/webpay-plus/refund/page.tsx
@@ -56,7 +56,7 @@ export default async function RefundTransaction({
                 están soportadas.`}
       actualBread={actualBread}
       activeRoute="/webpay-plus/refund"
-      steps={getRefundTRXSteps(refundResult, amount as string)}
+      steps={getRefundTRXSteps(refundResult, amount as string, token_ws as string)}
       additionalContent={<StatusButton className="mt-6" token={token_ws} />}
     />
   );


### PR DESCRIPTION
This PR updates the snippets presented to the user on all different Webpay products and Patpass, considering that the latest SDK release (6.0.0) requires explicit credentials configuration for integration environment. This update uses the Options class to implement it applying the following structure as an example:

## Before
![image](https://github.com/user-attachments/assets/a500f217-d6d1-4354-95f4-1d5ce7e729bc)

## After
<img width="716" alt="Captura de pantalla 2025-05-09 a la(s) 2 48 36 p m" src="https://github.com/user-attachments/assets/b9903728-bbb8-47dd-86bb-d466c46da49e" />

## Additional changes
1. The project now uses the transbank SDK version `6.0.0`
2. The `token_ws` comments in code snippets for Webpay Plus, Webpay Plus Mall, and their respective deferred versions have been updated: they now dynamically display the actual token_ws relevant to each specific scenario, replacing previous static placeholder values.
3. Resolved import path errors for several deferred snippets:
- Webpay Plus Deferred imports its own snippets instead of those from Webpay Plus.
- Webpay Plus Mall Deferred imports its own snippets instead of those from Webpay Plus Mall.
- Oneclick Mall Deferred imports its own snippets instead of those from Oneclick Mall.
4. The Patpass implementation within `lib/patpass-comercio/data.ts` has been updated to utilize the `PatpassEnvironment` enum
