### PR TITLE
docs: mall codes identified

### DIFF
--- a/src/app/oneclick-mall-deferred/content/snippets/authorize.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/authorize.ts
@@ -8,8 +8,14 @@ export const getStepOne = () => {
 ));
 
 const details = [
-  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1), // Código de comercio Tienda 1
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2) // Código de comercio Tienda 2
+  new TransactionDetail(
+    amount,
+    commerceCodeStore1, // Código de comercio Tienda 1
+    buyOrderStore1),
+  new TransactionDetail(
+    amount2,
+    commerceCodeStore2, // Código de comercio Tienda 2
+    buyOrderStore2)
 )];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/oneclick-mall-deferred/content/snippets/authorize.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/authorize.ts
@@ -2,14 +2,14 @@ import { TBKAuthorizeTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
   return `const tx = new Oneclick.MallTransaction(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const details = [
-  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1), 
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2)
+  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1), // Código de comercio Tienda 1
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2) // Código de comercio Tienda 2
 )];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/oneclick-mall-deferred/content/snippets/capture.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/capture.ts
@@ -4,13 +4,13 @@ export const getStepOne = (token: string) => {
   return `//buyOrderStore: ${token}
 
 const tx = new Oneclick.MallTransaction(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const captureResponse = await tx.capture(
-  commerceCode,
+  commerceCodeStore, // Código de comercio Tienda
   buyOrderStore,
   authorizationCode,
   captureAmount

--- a/src/app/oneclick-mall-deferred/content/snippets/create.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/create.ts
@@ -18,7 +18,7 @@ TransactionDetail
 } from 'transbank-sdk'; // ES6
 
 const tx = new Oneclick.MallInscription(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
@@ -27,7 +27,7 @@ const createResponse = await tx.start(
   userName,
   email,
   returnUrl
-);`;
+)`;
 };
 
 export const getStepTwo = (token: string) => {

--- a/src/app/oneclick-mall-deferred/content/snippets/finish.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/finish.ts
@@ -10,7 +10,7 @@ export const getStepTwo = () => {
   return `const token = request.body.TBK_TOKEN;
 
 const tx = new Oneclick.MallInscription(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/oneclick-mall-deferred/content/snippets/refund.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/refund.ts
@@ -5,16 +5,16 @@ export const getStepOne = (buyOrder: string, amount: string) => {
 // Amount: ${amount}
 
 const tx = new Oneclick.MallTransaction(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const refundRequest = await tx.refund(
   buyOrder,
-  commerceCodeStore,
+  commerceCodeStore, // Código de comercio Tienda
   buyOrderStore,
-  amount
+  amount
 );`;
 };
 

--- a/src/app/oneclick-mall-deferred/content/snippets/remove-user.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/remove-user.ts
@@ -3,7 +3,7 @@ export const getStepOne = (tbkUser: string, userName: string) => {
 //userName ${userName}
 
 const tx = new Oneclick.MallInscription(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/oneclick-mall-deferred/content/snippets/status.ts
+++ b/src/app/oneclick-mall-deferred/content/snippets/status.ts
@@ -4,7 +4,7 @@ export const getStepOne = (buyOrder: string) => {
   return `const buyOrder = "${buyOrder}";
 
 const tx = new Oneclick.MallTransaction(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+  IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/oneclick-mall/content/snippets/authorize.ts
+++ b/src/app/oneclick-mall/content/snippets/authorize.ts
@@ -2,14 +2,14 @@ import { TBKAuthorizeTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
   return `const tx = new Oneclick.MallTransaction(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationCommerceCodes.ONECLICK_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const details = [
-  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1), 
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2)
+  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1), // Código de comercio Tienda 1
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2) // Código de comercio Tienda 2
 )];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/oneclick-mall/content/snippets/authorize.ts
+++ b/src/app/oneclick-mall/content/snippets/authorize.ts
@@ -8,8 +8,14 @@ export const getStepOne = () => {
 ));
 
 const details = [
-  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1), // Código de comercio Tienda 1
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2) // Código de comercio Tienda 2
+  new TransactionDetail(
+    amount,
+    commerceCodeStore1, // Código de comercio Tienda 1
+    buyOrderStore1),
+  new TransactionDetail(
+    amount2,
+    commerceCodeStore2, // Código de comercio Tienda 2
+    buyOrderStore2)
 )];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/oneclick-mall/content/snippets/create.ts
+++ b/src/app/oneclick-mall/content/snippets/create.ts
@@ -18,7 +18,7 @@ TransactionDetail
 } from 'transbank-sdk'; // ES6
 
 const tx = new Oneclick.MallInscription(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationCommerceCodes.ONECLICK_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/oneclick-mall/content/snippets/finish.ts
+++ b/src/app/oneclick-mall/content/snippets/finish.ts
@@ -10,7 +10,7 @@ export const getStepTwo = () => {
   return `const token = request.body.TBK_TOKEN;
 
 const tx = new Oneclick.MallInscription(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationCommerceCodes.ONECLICK_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/oneclick-mall/content/snippets/refund.ts
+++ b/src/app/oneclick-mall/content/snippets/refund.ts
@@ -5,14 +5,14 @@ export const getStepOne = (buyOrder: string, amount: string) => {
 // Amount: ${amount}
 
 const tx = new Oneclick.MallTransaction(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationCommerceCodes.ONECLICK_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const refundRequest = await tx.refund(
   buyOrder,
-  commerceCodeStore,
+  commerceCodeStore, // Código de comercio Tienda
   buyOrderStore,
   amount
 );`;

--- a/src/app/oneclick-mall/content/snippets/remove-user.ts
+++ b/src/app/oneclick-mall/content/snippets/remove-user.ts
@@ -3,7 +3,7 @@ export const getStepOne = (tbkUser: string, userName: string) => {
 //userName: ${userName}
 
 const tx = new Oneclick.MallInscription(
-  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationCommerceCodes.ONECLICK_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 );

--- a/src/app/oneclick-mall/content/snippets/status.ts
+++ b/src/app/oneclick-mall/content/snippets/status.ts
@@ -3,7 +3,7 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 export const getStepOne = (buyOrder: string) => {
   return `const buyOrder = "${buyOrder}";
 const tx = new Oneclick.MallTransaction(new Options(
-  IntegrationCommerceCodes.ONECLICK_MALL,
+  IntegrationCommerceCodes.ONECLICK_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/transaccion-completa-mall-diferido/capture/page.tsx
+++ b/src/app/transaccion-completa-mall-diferido/capture/page.tsx
@@ -1,7 +1,7 @@
 import { Route } from "@/types/menu";
 import Head from "next/head";
 import { Layout } from "@/components/layout/Layout";
-import { getCaptureSteps } from "@/app/transaccion-completa-diferido/content/steps/capture";
+import { getCaptureSteps } from "@/app/transaccion-completa-mall-diferido/content/steps/capture";
 import { NavigationItem } from "@/components/layout/Navigation";
 import { NextPageProps } from "@/types/general";
 import { captureTransaccionCompletaMallDeferido } from "@/app/lib/transaccion-completa-mall-diferido/data";

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/capture.tsx
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/capture.tsx
@@ -1,0 +1,27 @@
+import { TBKfullTxCaptureResponse } from "@/types/transactions";
+
+export const getStepOne = () => {
+  return `const tx = new TransaccionCompleta.Transaction(new Options(
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED, // Código de comercio Mall
+  IntegrationApiKeys.WEBPAY,
+  Environment.Integration
+));
+
+const resp = await tx.capture(
+  token,
+  buyOrderStore,
+  commerceCodeStore, // Código de comercio Tienda
+  authorizationCode,
+  captureAmount
+);`;
+};
+
+export const getStepTwo = (captureResponse: TBKfullTxCaptureResponse) => {
+  return `{
+  "authorization_code": "${captureResponse.authorization_code}",
+  "authorization_date": "${captureResponse.authorization_date}",
+  "captured_amount": ${captureResponse.captured_amount},
+  "response_code": ${captureResponse.response_code}
+}
+ `;
+};

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/commit.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/commit.ts
@@ -2,21 +2,21 @@ import { TBKMallCommitTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
   return `const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED, // Código de comercio Mall 
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const details = [
   new CommitDetail(
-    commerceCodeStore1,
+    commerceCodeStore1, // Código de comercio Tienda 1
     buyOrderStore1,
     idQueryInstallments1,
     deferredPeriodIndex1,
     gracePeriod1
   ),
   new CommitDetail(
-    commerceCodeStore2,
+    commerceCodeStore2, // Código de comercio Tienda 2
     buyOrderStore2,
     idQueryInstallments2,
     deferredPeriodIndex2,

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/create.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/create.ts
@@ -28,8 +28,14 @@ const tx = new TransaccionCompleta.MallTransaction(new Options(
 ));
   
 const details = [
-  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1) // Código de comercio Tienda 1
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2) // Código de comercio Tienda 2
+  new TransactionDetail(
+    amount, 
+    commerceCodeStore1, // Código de comercio Tienda 1 
+    buyOrderStore1), 
+  new TransactionDetail(
+    amount2,
+    commerceCodeStore2, // Código de comercio Tienda 2
+    buyOrderStore2)
 ];
   
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/create.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/create.ts
@@ -22,14 +22,14 @@ TransactionDetail
 } from 'transbank-sdk'; // ES6
 
 const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
   
 const details = [
-  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1)
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2)
+  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1) // Código de comercio Tienda 1
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2) // Código de comercio Tienda 2
 ];
   
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/installments.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/installments.ts
@@ -2,14 +2,14 @@ import { TBKInstallmentsFullTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
   return `const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const installmentDetails = [
-  new InstallmentDetail(commerceCodeStore1, buyOrderStore1, installmentsNumber)
-  new InstallmentDetail(commerceCodeStore2, buyOrderStore2, installmentsNumber)
+  new InstallmentDetail(commerceCodeStore1, buyOrderStore1, installmentsNumber) // Código de comercio Tienda 1
+  new InstallmentDetail(commerceCodeStore2, buyOrderStore2, installmentsNumber) // Código de comercio Tienda 2
 ];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/installments.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/installments.ts
@@ -8,8 +8,14 @@ export const getStepOne = () => {
 ));
 
 const installmentDetails = [
-  new InstallmentDetail(commerceCodeStore1, buyOrderStore1, installmentsNumber) // Código de comercio Tienda 1
-  new InstallmentDetail(commerceCodeStore2, buyOrderStore2, installmentsNumber) // Código de comercio Tienda 2
+  new InstallmentDetail(
+    commerceCodeStore1, // Código de comercio Tienda 1
+    buyOrderStore1,
+    installmentsNumber),
+  new InstallmentDetail(
+    commerceCodeStore2, // Código de comercio Tienda 2
+    buyOrderStore2, 
+    installmentsNumber) 
 ];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/refund.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/refund.ts
@@ -4,13 +4,16 @@ export const getStepOne = (token: string, amount: string) => {
   return `// Token: ${token}
 // Amount: ${amount}
 const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const refundRequest = await tx.refund(
-  token, buyOrder, commerceCode, amount
+  token,
+  buyOrderStore,
+  commerceCodeStore, // Código de comercio Tienda
+  amount
 );`;
 };
 

--- a/src/app/transaccion-completa-mall-diferido/content/snippets/status.ts
+++ b/src/app/transaccion-completa-mall-diferido/content/snippets/status.ts
@@ -3,7 +3,7 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 export const getStepOne = (token: string) => {
   return `// Token: ${token}
 const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/transaccion-completa-mall-diferido/content/steps/capture.tsx
+++ b/src/app/transaccion-completa-mall-diferido/content/steps/capture.tsx
@@ -1,0 +1,40 @@
+import { StepProps } from "@/components/step/Step";
+import { TBKfullTxCaptureResponse } from "@/types/transactions";
+import * as captureSnippets from "@/app/transaccion-completa-mall-diferido/content/snippets/capture";
+import { OperationsCaptureMessage } from "@/components/messages/OperationsCaptureMessage";
+
+export const getCaptureSteps = (
+  captureResponse: TBKfullTxCaptureResponse
+): StepProps[] => {
+  return [
+    {
+      stepTitle: "Paso 1 - Petición:",
+      stepId: "peticion",
+      content: (
+        <p>
+          Para capturar una transacción, necesitaremos el Token, la Orden de
+          compra, el Código de comercio , el Código de autorización y el monto a capturar.
+        </p>
+      ),
+      code: captureSnippets.getStepOne(),
+    },
+    {
+      stepTitle: "Paso 2: Respuesta",
+      content: (
+        <p>
+          Una vez creada la transacción, recibirás los siguientes datos de
+          respuesta:
+        </p>
+      ),
+      code: captureSnippets.getStepTwo(captureResponse),
+    },
+
+    {
+      stepTitle: "¡Listo!",
+      stepId: "other",
+      content: (
+        <OperationsCaptureMessage />
+      ),
+    },
+  ];
+};

--- a/src/app/transaccion-completa-mall/content/snippets/commit.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/commit.ts
@@ -2,21 +2,21 @@ import { TBKMallCommitTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
   return `const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const details = [
   new CommitDetail(
-    commerceCodeStore1,
+    commerceCodeStore1, // Código de comercio Tienda 1
     buyOrderStore1,
     idQueryInstallments1,
     deferredPeriodIndex1,
     gracePeriod1
   ),
   new CommitDetail(
-    commerceCodeStore2,
+    commerceCodeStore2, // Código de comercio Tienda 2
     buyOrderStore2,
     idQueryInstallments2,
     deferredPeriodIndex2,

--- a/src/app/transaccion-completa-mall/content/snippets/create.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/create.ts
@@ -28,8 +28,14 @@ const tx = new TransaccionCompleta.MallTransaction(new Options(
 ));
   
 const details = [
-  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1) // Código de comercio Tienda 1
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2) // Código de comercio Tienda 2
+  new TransactionDetail(
+    amount, 
+    commerceCodeStore1, // Código de comercio Tienda 1 
+    buyOrderStore1),
+  new TransactionDetail(
+    amount2,
+    commerceCodeStore2, // Código de comercio Tienda 2
+    buyOrderStore2)
 ];
   
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall/content/snippets/create.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/create.ts
@@ -22,14 +22,14 @@ TransactionDetail
 } from 'transbank-sdk'; // ES6
 
 const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
   
 const details = [
-  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1)
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2)
+  new TransactionDetail(amount, commerceCodeStore1, buyOrderStore1) // Código de comercio Tienda 1
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2) // Código de comercio Tienda 2
 ];
   
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall/content/snippets/installments.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/installments.ts
@@ -2,14 +2,14 @@ import { TBKInstallmentsFullTransactionResponse } from "@/types/transactions";
 
 export const getStepOne = () => {
   return `const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const installmentDetails = [
-  new InstallmentDetail(commerceCodeStore1, buyOrderStore1, installmentsNumber)
-  new InstallmentDetail(commerceCodeStore2, buyOrderStore2, installmentsNumber)
+  new InstallmentDetail(commerceCodeStore1, buyOrderStore1, installmentsNumber) // Código de comercio Tienda 1
+  new InstallmentDetail(commerceCodeStore2, buyOrderStore2, installmentsNumber) // Código de comercio Tienda 2
 ];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall/content/snippets/installments.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/installments.ts
@@ -8,8 +8,14 @@ export const getStepOne = () => {
 ));
 
 const installmentDetails = [
-  new InstallmentDetail(commerceCodeStore1, buyOrderStore1, installmentsNumber) // Código de comercio Tienda 1
-  new InstallmentDetail(commerceCodeStore2, buyOrderStore2, installmentsNumber) // Código de comercio Tienda 2
+  new InstallmentDetail(
+    commerceCodeStore1, // Código de comercio Tienda 1
+    buyOrderStore1,
+    installmentsNumber),
+  new InstallmentDetail(
+    commerceCodeStore2, // Código de comercio Tienda 2
+    buyOrderStore2,
+    installmentsNumber)
 ];
 
 // Es necesario ejecutar dentro de una función async para utilizar await

--- a/src/app/transaccion-completa-mall/content/snippets/refund.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/refund.ts
@@ -5,7 +5,7 @@ export const getStepOne = (token: string, amount: string) => {
 // Amount: ${amount}
 
 const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/transaccion-completa-mall/content/snippets/refund.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/refund.ts
@@ -11,7 +11,10 @@ const tx = new TransaccionCompleta.MallTransaction(new Options(
 ));
 
 const refundRequest = await tx.refund(
-  token, buyOrder, commerceCode, amount
+  token,
+  buyOrderStore,
+  commerceCodeStore, // Código de comercio Tienda
+  amount
 );`;
 };
 

--- a/src/app/transaccion-completa-mall/content/snippets/status.ts
+++ b/src/app/transaccion-completa-mall/content/snippets/status.ts
@@ -3,7 +3,7 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 export const getStepOne = (token: string) => {
   return `// Token: ${token}
 const tx = new TransaccionCompleta.MallTransaction(new Options(
-  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+  IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/webpay-mall-diferido/content/snippets/capture.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/capture.ts
@@ -3,14 +3,15 @@ import { TBKCaptureTransactionResponse } from "@/types/transactions";
 export const getStepOne = (token: string) => {
   return `//token: ${token}
 const tx = new WebpayPlus.Transaction(new Options(
-  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const captureResponse = await tx.capture(
   token,
-  buyOrder,
+  buyOrderStore,
+  commerceCodeStore, // Código de comercio Tienda
   authorizationCode,
   captureAmount
 );`;

--- a/src/app/webpay-mall-diferido/content/snippets/commit.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/commit.ts
@@ -10,7 +10,7 @@ export const getStepTwo = () => {
   return `const token = request.body.token_ws;
 
 const tx = new WebpayPlus.MallTransaction(new Options(
-  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/webpay-mall-diferido/content/snippets/create.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/create.ts
@@ -24,8 +24,14 @@ const tx = new WebpayPlus.MallTransaction(new Options(
 ));
 
 let details = [
-  new TransactionDetail(amount1, commerceCodeStore1, buyOrderStore1), // Código de comercio Tienda 1
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2), // Código de comercio Tienda 2
+  new TransactionDetail(
+    amount,
+    commerceCodeStore1, // Código de comercio Tienda 1
+    buyOrderStore1),
+  new TransactionDetail(
+    amount2,
+    commerceCodeStore2, // Código de comercio Tienda 2
+    buyOrderStore2)
 ]
   
 const createResponse = await tx.create(

--- a/src/app/webpay-mall-diferido/content/snippets/create.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/create.ts
@@ -7,7 +7,7 @@ Options,
 TransactionDetail,
 WebpayPlus
 } = require('transbank-sdk') // ES5
- 
+
 import { 
 Environment,
 IntegrationApiKeys,
@@ -18,14 +18,14 @@ WebpayPlus
 } from 'transbank-sdk'; // ES6
 
 const tx = new WebpayPlus.MallTransaction(new Options(
-  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 let details = [
-  new TransactionDetail(135, "597055555536", "O-23101"),
-  new TransactionDetail(148, "597055555536", "O-10821"),
+  new TransactionDetail(amount1, commerceCodeStore1, buyOrderStore1), // Código de comercio Tienda 1
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2), // Código de comercio Tienda 2
 ]
   
 const createResponse = await tx.create(

--- a/src/app/webpay-mall-diferido/content/snippets/refund.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/refund.ts
@@ -4,15 +4,15 @@ export const getStepOne = (amount: string, token_ws: string) => {
   return `// Token: ${token_ws}
 // Amount: ${amount}
 const tx = new WebpayPlus.MallTransaction(new Options(
-  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 const refundRequest = await tx.refund(
   token,
-  buyOrder,
-  commerceCode,
+  buyOrderStore,
+  commerceCodeStore, // Código de comercio Tienda
   amount
 );`;
 };

--- a/src/app/webpay-mall-diferido/content/snippets/status.ts
+++ b/src/app/webpay-mall-diferido/content/snippets/status.ts
@@ -3,7 +3,7 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 export const getStepOne = (token_ws: string) => {
   return `// Token: ${token_ws}
 const tx = new WebpayPlus.MallTransaction(new Options(
-  IntegrationCommercecodes.WEBPAY_PLUS_MALL_DEFERRED,
+  IntegrationCommercecodes.WEBPAY_PLUS_MALL_DEFERRED, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/webpay-mall/content/snippets/commit.ts
+++ b/src/app/webpay-mall/content/snippets/commit.ts
@@ -9,7 +9,7 @@ export const getStepOne = (token: string) => {
 export const getStepTwo = () => {
   return `const token = request.body.token_ws;
 const tx = new WebpayPlus.MallTransaction(new Options(
-  IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));

--- a/src/app/webpay-mall/content/snippets/create.ts
+++ b/src/app/webpay-mall/content/snippets/create.ts
@@ -18,14 +18,14 @@ WebpayPlus
 } from 'transbank-sdk'; // ES6
 
 const tx = new WebpayPlus.MallTransaction(new Options(
-  IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
 
 let details = [
-  new TransactionDetail(135, "597055555536", "O-23101"),
-  new TransactionDetail(148, "597055555536", "O-10821"),
+  new TransactionDetail(amount1, commerceCodeStore1, buyOrderStore1), // Código de comercio Tienda 1
+  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2), // Código de comercio Tienda 2
 ]
   
 const createResponse = await tx.create(

--- a/src/app/webpay-mall/content/snippets/create.ts
+++ b/src/app/webpay-mall/content/snippets/create.ts
@@ -24,8 +24,14 @@ const tx = new WebpayPlus.MallTransaction(new Options(
 ));
 
 let details = [
-  new TransactionDetail(amount1, commerceCodeStore1, buyOrderStore1), // Código de comercio Tienda 1
-  new TransactionDetail(amount2, commerceCodeStore2, buyOrderStore2), // Código de comercio Tienda 2
+  new TransactionDetail(
+    amount,
+    commerceCodeStore1, // Código de comercio Tienda 1
+    buyOrderStore1),
+  new TransactionDetail(
+    amount2,
+    commerceCodeStore2, // Código de comercio Tienda 2
+    buyOrderStore2)
 ]
   
 const createResponse = await tx.create(

--- a/src/app/webpay-mall/content/snippets/refund.ts
+++ b/src/app/webpay-mall/content/snippets/refund.ts
@@ -4,14 +4,15 @@ export const getStepOne = (amount: string, token_ws: string) => {
   return `// Token: ${token_ws}
 // Amount: ${amount}
 const tx = new WebpayPlus.MallTransaction(new Options(
-  IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));
+
 const refundRequest = await tx.refund(
   token,
-  buyOrder,
-  commerceCode,
+  buyOrderStore,
+  commerceCodeStore, // Código de comercio Tienda
   amount
 );`;
 };

--- a/src/app/webpay-mall/content/snippets/status.ts
+++ b/src/app/webpay-mall/content/snippets/status.ts
@@ -3,7 +3,7 @@ import { TBKMallTransactionStatusResponse } from "@/types/transactions";
 export const getStepOne = (token_ws: string) => {
   return `// Token: ${token_ws}
 const tx = new WebpayPlus.MallTransaction(new Options(
-  IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+  IntegrationCommerceCodes.WEBPAY_PLUS_MALL, // Código de comercio Mall
   IntegrationApiKeys.WEBPAY,
   Environment.Integration
 ));


### PR DESCRIPTION
This PR identifies the usage of Mall commerce code and Store commerce code across their snippets. This change has been applied using this format as example:

## Before
![snippet-webpay-mall](https://github.com/user-attachments/assets/4f8a387d-e531-4ee1-988d-1d1ee1ede14c)

## After
![Captura de pantalla 2025-05-15 a la(s) 9 22 47 a m](https://github.com/user-attachments/assets/3d8e0678-010e-4f37-82cf-cf8fed86faf0)
