### PR TITLE
fix: contents webpay mall

### DIFF
--- a/src/app/webpay-mall/commit/error/aborted.tsx
+++ b/src/app/webpay-mall/commit/error/aborted.tsx
@@ -14,12 +14,12 @@ const actualBread: Route[] = [
     path: "/",
   },
   {
-    name: "Webpay Plus",
-    path: "/webpay-plus",
+    name: "Webpay Mall",
+    path: "/webpay-mall",
   },
   {
     name: "Estado cancelada",
-    path: "/webpay-plus/commit",
+    path: "/webpay-mall/commit",
   },
 ];
 
@@ -44,7 +44,7 @@ export const AbortedView = async (props: AbortedViewProps) => {
         <title>Transbank SDK Node - Estado cancelada</title>
       </Head>
       <Layout
-        pageTitle="Webpay Plus - Estado de compra cancelada"
+        pageTitle="Webpay Mall - Estado de compra cancelada"
         pageDescription={
           <span>
             El pago de la compra ha sido anulado por el usuario. En esta etapa,
@@ -54,7 +54,7 @@ export const AbortedView = async (props: AbortedViewProps) => {
           </span>
         }
         actualBread={actualBread}
-        activeRoute="/webpay-plus/commit"
+        activeRoute="/webpay-mall/commit"
         steps={getErrorAbortedSteps(props.abortedResponse)}
         additionalContent={
           <div className="aborted-status">

--- a/src/app/webpay-mall/commit/error/timeout.tsx
+++ b/src/app/webpay-mall/commit/error/timeout.tsx
@@ -10,12 +10,12 @@ const actualBread: Route[] = [
     path: "/",
   },
   {
-    name: "Webpay Plus",
-    path: "/webpay-plus",
+    name: "Webpay Mall",
+    path: "/webpay-mall",
   },
   {
     name: "Time out",
-    path: "/webpay-plus/commit",
+    path: "/webpay-mall/commit",
   },
 ];
 
@@ -31,7 +31,7 @@ export const TimeoutView = async (props: TimeoutViewProps) => {
         <title>Transbank SDK Node - Time out</title>
       </Head>
       <Layout
-        pageTitle="Webpay Plus - Time out"
+        pageTitle="Webpay Mall - Time out"
         pageDescription={
           <span>
             Cuando una transacción expira debido a un timeout, es crucial
@@ -41,7 +41,7 @@ export const TimeoutView = async (props: TimeoutViewProps) => {
           </span>
         }
         actualBread={actualBread}
-        activeRoute="/webpay-plus/commit"
+        activeRoute="/webpay-mall/commit"
         steps={getErrorTimeoutSteps(props.timeoutResponse)}
       />
     </>

--- a/src/app/webpay-mall/commit/page.tsx
+++ b/src/app/webpay-mall/commit/page.tsx
@@ -64,7 +64,7 @@ const commitContent = {
 };
 
 const rejectedContent = {
-  title: "Webpay Mall - Rechazo Bancario",
+  title: "Webpay Mall - Rechazo bancario",
   description: (
     <span>
       En esta fase, pueden surgir inconvenientes, ya sea con el titular de la

--- a/src/app/webpay-mall/commit/page.tsx
+++ b/src/app/webpay-mall/commit/page.tsx
@@ -28,7 +28,7 @@ const getActualBread = (isRejected: boolean): Route[] => {
       path: "/",
     },
     {
-      name: "Webpay Plus",
+      name: "Webpay Mall",
       path: "/webpay-mall",
     },
     {

--- a/src/app/webpay-mall/content/steps/commit.tsx
+++ b/src/app/webpay-mall/content/steps/commit.tsx
@@ -3,12 +3,13 @@ import { TBKMallCommitTransactionResponse } from "@/types/transactions";
 import * as commitSnippets from "@/app/webpay-mall/content/snippets/commit";
 import { Text } from "@/components/text/Text";
 import { OkCommitMessage } from "@/components/messages/OkCommitMessage";
+import { isSomeTransactionRejected } from "@/helpers/transactions/transactionHelper";
 
 export const getCommitSteps = (
   token: string,
   commitResponse: TBKMallCommitTransactionResponse
 ): StepProps[] => {
-  return [
+  const steps: StepProps[] = [
     {
       stepTitle: "Paso 1: Datos recibidos",
       stepId: "confirmar",
@@ -37,7 +38,14 @@ export const getCommitSteps = (
       ),
       code: commitSnippets.getStepThree(commitResponse),
     },
-    {
+  ];
+
+  const isAuthorizedCommit = !isSomeTransactionRejected(
+    commitResponse.details,
+  );
+
+  if (isAuthorizedCommit) {
+    steps.push({
       stepTitle: "¡Listo!",
       stepId: "consultas",
       content: (
@@ -65,6 +73,8 @@ export const getCommitSteps = (
           </div>
         </div>
       ),
-    },
-  ];
+    });
+  }
+
+  return steps;
 };


### PR DESCRIPTION
this PR applies fixes to content errors found on different flows executed in Webpay Mall

## Tests
### 1. On transaction success: 
### Before
<img width="1288" height="378" alt="Confirmar tx - error" src="https://github.com/user-attachments/assets/ac3aaf50-3f4a-44f5-a66a-dd26f3729d5a" />

### After
<img width="1295" height="328" alt="Confirmar tx - solución" src="https://github.com/user-attachments/assets/8b985ac6-3db8-4fe9-9512-d37112440f28" />

### 2. On transaction reject
### Before
<img width="1286" height="356" alt="Rechazo bancario - error 1" src="https://github.com/user-attachments/assets/a8f93122-8a8b-4913-ab14-ec7767f826c5" />

---

<img width="1290" height="769" alt="Rechazo bancario - error 2" src="https://github.com/user-attachments/assets/f5fcfd96-0daa-465f-8497-d6208f6d00a5" />

### After
<img width="1297" height="325" alt="Rechazo bancario - solución 1" src="https://github.com/user-attachments/assets/24d51c34-73b6-4d03-bbf7-8ec06feca073" />

---

<img width="1293" height="725" alt="Rechazo bancario - solución 2" src="https://github.com/user-attachments/assets/d5bc6f40-68d6-4a07-bc2c-5426097002e8" />

### 3. On transaction cancellation
### Before
<img width="1286" height="378" alt="Compra cancelada - error" src="https://github.com/user-attachments/assets/6555b746-0c15-4a2e-874f-4e0b1e7178ef" />

### After
<img width="1295" height="329" alt="Compra cancelada - solución" src="https://github.com/user-attachments/assets/542ee972-9a03-420b-bf8c-11cbca80e83f" />

### 4. On transaction time out
### Before
<img width="1292" height="384" alt="Timeout - error" src="https://github.com/user-attachments/assets/89a8cccf-5b34-4538-9fd8-09dea290835d" />

### After
<img width="1294" height="335" alt="Timeout - solución" src="https://github.com/user-attachments/assets/0a0c0539-94f2-4972-a6a8-093b37795b61" />




